### PR TITLE
Handling of systematics with friend trees

### DIFF
--- a/Gardener/python/Gardener_cfg.py
+++ b/Gardener/python/Gardener_cfg.py
@@ -2129,6 +2129,22 @@ Steps= {
                   'onlySample' : samples4Syst
                 },
 
+  'FJESup'     :  {
+                  'isChain'    : True ,
+                  'do4MC'      : True ,
+                  'do4Data'    : False,
+                  'subTargets' : ['Fdo_JESup','FbPogSF','Fl2kin','Fl3kin','Fl4kin','Fdo_dymvaHiggs','FformulasMC'],
+                  'onlySample' : samples4Syst
+                },
+
+  'FJESdo'     :  {
+                  'isChain'    : True ,
+                  'do4MC'      : True ,
+                  'do4Data'    : False,
+                  'subTargets' : ['Fdo_JESdo','FbPogSF','Fl2kin','Fl3kin','Fl4kin','Fdo_dymvaHiggs','FformulasMC'],
+                  'onlySample' : samples4Syst
+                }, 
+
 
   'JESMaxup'     :  {
                   'isChain'    : True ,
@@ -2710,6 +2726,13 @@ Steps= {
                   'command'    : 'gardener.py l2kinfiller --cmssw RPLME_CMSSW'
                },
 
+  'Fl2kin'    : {
+                  'isChain'    : False ,
+                  'do4MC'      : True  ,
+                  'do4Data'    : True  ,
+                  'command'    : 'gardener.py l2kinfiller --cmssw RPLME_CMSSW --auxiliaryFile=RPLME_AUX'
+  },
+
   'l2kin_metXYshift'    : {
                   'isChain'    : False ,
                   'do4MC'      : True  ,
@@ -2725,6 +2748,13 @@ Steps= {
                },
 
 
+  'Fl3kin'    : {
+                  'isChain'    : False ,
+                  'do4MC'      : True  ,
+                  'do4Data'    : True  ,
+                  'command'    : 'gardener.py l3kinfiller --cmssw RPLME_CMSSW --auxiliaryFile=RPLME_AUX'
+               },  
+
   'l4kin'    : {
                   'isChain'    : False ,
                   'do4MC'      : True  ,
@@ -2732,11 +2762,25 @@ Steps= {
                   'command'    : 'gardener.py l4kinfiller --cmssw RPLME_CMSSW'
                },
 
+  'Fl4kin'    : {
+                  'isChain'    : False ,
+                  'do4MC'      : True  ,
+                  'do4Data'    : True  ,
+                  'command'    : 'gardener.py l4kinfiller --cmssw RPLME_CMSSW --auxiliaryFile=RPLME_AUX'
+               },
+
   'formulasMC' : {
                   'isChain'    : False ,
                   'do4MC'      : True  ,
                   'do4Data'    : False ,
                   'command'    : 'gardener.py genericFormulaAdder -f data/formulasToAdd_MC.py'
+               },
+
+  'FformulasMC' : {
+                  'isChain'    : False ,
+                  'do4MC'      : True  ,
+                  'do4Data'    : False ,
+                  'command'    : 'gardener.py genericFormulaAdder -f data/formulasToAdd_MC.py --auxiliaryFile=RPLME_AUX'
                },
 
 
@@ -3067,12 +3111,27 @@ Steps= {
                   'command'    : 'gardener.py JESTreeMaker -k 1 --cmssw=RPLME_CMSSW'
                 } ,
 
+   'Fdo_JESup'    : {
+                  'isChain'    : False ,
+                  'do4MC'      : True  ,
+                  'do4Data'    : False ,
+                  'command'    : 'gardener.py JESTreeMaker -k 1 --cmssw=RPLME_CMSSW --saveOnlyModifiedBranches'
+                } , 
+
   'do_JESdo'    : {
                   'isChain'    : False ,
                   'do4MC'      : True  ,
                   'do4Data'    : False ,
                   'command'    : 'gardener.py JESTreeMaker -k -1 --cmssw=RPLME_CMSSW'
                 } ,
+
+   'Fdo_JESdo'    : {
+                  'isChain'    : False ,
+                  'do4MC'      : True  ,
+                  'do4Data'    : False ,
+                  'command'    : 'gardener.py JESTreeMaker -k -1 --cmssw=RPLME_CMSSW --saveOnlyModifiedBranches'
+                } ,
+
   
   'do_JESMaxup'    : {
                   'isChain'    : False ,
@@ -3097,6 +3156,15 @@ Steps= {
                   # --> switch to multiple bTag algo SF:
                   'command'    : 'gardener.py allBtagPogScaleFactors --cmssw=RPLME_CMSSW'
               },
+
+  'FbPogSF'   :{
+                  'isChain'    : False ,
+                  'do4MC'      : True  ,
+                  'do4Data'    : False  ,
+                  #'command'    : 'gardener.py btagPogScaleFactors '
+                  # --> switch to multiple bTag algo SF:
+                  'command'    : 'gardener.py allBtagPogScaleFactors --cmssw=RPLME_CMSSW --auxiliaryFile=RPLME_AUX'
+              }, 
 
   'do_LepElepTup'    : {
                    'isChain'    : False ,
@@ -3159,6 +3227,13 @@ Steps= {
                    'do4MC'      : True  ,
                    'do4Data'    : True ,
                    'command'    : 'gardener.py dymvaHiggsFiller',
+                },
+  
+   'Fdo_dymvaHiggs'  : {
+                   'isChain'    : False ,
+                   'do4MC'      : True  ,
+                   'do4Data'    : True ,
+                   'command'    : 'gardener.py dymvaHiggsFiller --auxiliaryFile=RPLME_AUX',
                 },
  
    'Mucca'       :  {
@@ -3592,6 +3667,13 @@ Steps= {
                   'do4MC'      : True  ,
                   'do4Data'    : True  ,
                   'command'    : 'gardener.py filter -f \' mll>12 && std_vector_lepton_pt[0]>20 && std_vector_lepton_pt[1]>10 && std_vector_lepton_pt[2]<10 && metPfType1 > 20 && ptll > 30 && (std_vector_lepton_flavour[0] * std_vector_lepton_flavour[1] == -11*13) \' '
+           },
+
+  'FwwSel'    : {
+                  'isChain'    : False ,
+                  'do4MC'      : True  ,
+                  'do4Data'    : True  ,
+                  'command'    : 'gardener.py filter -f \' mll>12 && std_vector_lepton_pt[0]>20 && std_vector_lepton_pt[1]>10 && std_vector_lepton_pt[2]<10 && metPfType1 > 20 && ptll > 30 && (std_vector_lepton_flavour[0] * std_vector_lepton_flavour[1] == -11*13) \'  --eventListOutput --auxiliaryFile=RPLME_AUX'
            },
 
   'monohSel'    : {

--- a/Gardener/python/gardening.py
+++ b/Gardener/python/gardening.py
@@ -47,7 +47,7 @@ class TreeCloner(object):
         group = optparse.OptionGroup(parser,self.label, description)
         group.add_option('--auxiliaryFile',dest='auxiliaryFile',help='auxiliary friend tree',default=None)
         group.add_option('--saveOnlyModifiedBranches', dest='saveOnlyModifiedBranches', help='whether to save only the modified branches of the whole tree (default=false)', default=False, action="store_true")
-        group.add_option('--eventListForFriend', dest='eventListForFriend', help='file containing the input list to be applied to the friend', default=None)
+        group.add_option('--eventListForFriend', dest='eventListForFriend', help='whether to load an event list from the pruner when reading the friend tree', default=False, action="store_true")
         parser.add_option_group(group)
         return group
 
@@ -92,9 +92,8 @@ class TreeCloner(object):
           print "Using auxiliary file ", self.auxiliaryFile
           self.friendFile = self._openRootFile(self.auxiliaryFile)
           self.friendTree = self._getRootObj(self.friendFile, self.itree.GetName())  
-          if self.eventListForFriend !=None:
-            self.friendFileList = self._openRootFile(self.eventListForFriend)
-            self.elist = self._getRootObj(self.friendFileList,"prunerlist")
+          if self.eventListForFriend :
+            self.elist = self._getRootObj(self.ifile,"prunerlist")
             self.itree.SetEventList(self.elist)
           self.itree.AddFriend(self.friendTree) 
           #self.itree.AddFriend(self.itree.GetName(), self.auxiliaryFile)
@@ -300,8 +299,9 @@ class Pruner(TreeCloner):
             otree.Fill()
 
         if self.eventListOutput:
-          ofileeventlist = ROOT.TFile("eventlist_"+output, "recreate")
-          ofileeventlist.cd()
+          #ofileeventlist = ROOT.TFile("eventlist_"+output, "recreate")
+          #ofileeventlist.cd()
+          self.ofile.cd()
           evlist.Write()
 
         self.disconnect()

--- a/Gardener/python/gardening.py
+++ b/Gardener/python/gardening.py
@@ -92,10 +92,13 @@ class TreeCloner(object):
           print "Using auxiliary file ", self.auxiliaryFile
           self.friendFile = self._openRootFile(self.auxiliaryFile)
           self.friendTree = self._getRootObj(self.friendFile, self.itree.GetName())  
+          self.friendTreeSkimmed = self.friendTree
           if self.eventListForFriend :
             self.elist = self._getRootObj(self.ifile,"prunerlist")
-            self.itree.SetEventList(self.elist)
-          self.itree.AddFriend(self.friendTree) 
+            self.friendTree.SetEventList(self.elist)
+            ROOT.gROOT.cd()
+            self.friendTreeSkimmed = self.friendTree.CopyTree("")
+          self.itree.AddFriend(self.friendTreeSkimmed) 
           #self.itree.AddFriend(self.itree.GetName(), self.auxiliaryFile)
 
     def clone(self,output,branches=[]):

--- a/Gardener/scripts/mkGardener.py
+++ b/Gardener/scripts/mkGardener.py
@@ -81,6 +81,7 @@ parser = OptionParser(usage="usage: %prog [options]")
 parser.add_option("-p","--prods",   dest="prods"   , help="List of production to run on"              , default=[]     , type='string' , action='callback' , callback=list_maker('prods',','))
 parser.add_option("-s","--steps",   dest="steps"   , help="list of Steps to produce"                  , default=[]     , type='string' , action='callback' , callback=list_maker('steps',','))
 parser.add_option("-i","--iniStep",   dest="iniStep"   , help="Step to restart from"                      , default='Prod' , type='string' ) 
+parser.add_option(     "--friendStep",dest="friendStep"   , help="step to use as auxiliary input file (default None)"    , default=None , type='string' ) 
 parser.add_option("-R","--redo" ,   dest="redo"    , help="Redo, don't check if tree already exists"  , default=False  , action="store_true")
 parser.add_option("-b","--batch",   dest="runBatch", help="Run in batch"                              , default=False  , action="store_true")
 parser.add_option("-S","--batchSplit", dest="batchSplit", help="Splitting mode for batch jobs"        , default='Target', type='string' , action='callback' , callback=list_maker('batchSplit',','))
@@ -680,13 +681,12 @@ for iProd in prodList :
               if not Steps[iSubStep]['do4MC'] : selectSample=False
 
 
-            #print iSubStep , selectSample
 
             if cStep == 1 :
               iName=iSubStep
             else:
               iName+='__'+iSubStep
-
+            
             if selectSample : 
               inTree=finalTree              
               outTree ='latino_'+iTarget+'__'+iName+'.root'
@@ -710,6 +710,8 @@ for iProd in prodList :
 
         # Fix CMSSW flag
         command = command.replace('RPLME_CMSSW',cmssw)
+        if options.friendStep != None:
+          command = command.replace('RPLME_AUX',targetList[iTarget].replace(options.iniStep, options.friendStep))
         # Fix baseW if needed
         if Productions[iProd]['isData'] : baseW = '1.'
         elif iStep == 'baseW' or ( 'isChain' in Steps[iStep] and Steps[iStep]['isChain'] and 'baseW' in Steps[iStep]['subTargets'] ): 


### PR DESCRIPTION
This pull request hopefully integrates the possibility of using friend trees for systematics.
Changes are:
- all gardener modules can output only the modified branches
- all gardener modules can use as input a friend tree for the unmodified branches
- the pruner module outputs a TEventList of the selected events
- mkShapes can handle friend trees (new option unskimmedFriendTreeDir) (example missing)
- full chain implemented in mkGardener.py steps FJESdo, FJESup and FwwSel (to be extended to other steps if needed)
- original behavior preserved
