### PR TITLE
Changes to facilitate larger scale operations

### DIFF
--- a/ShapeAnalysis/python/PlotFactory.py
+++ b/ShapeAnalysis/python/PlotFactory.py
@@ -24,6 +24,8 @@ class PlotFactory:
     # _____________________________________________________________________________
     def __init__(self):
 
+        self._tag = ''
+
         variables = {}
         self._variables = variables
 
@@ -101,12 +103,28 @@ class PlotFactory:
 
         generalCounter = 0
 
-        fileIn = ROOT.TFile(inputFile, "READ")
+        if os.path.isdir(inputFile):
+          # ONLY COMPATIBLE WITH OUTPUTS MERGED TO SAMPLE LEVEL!!
+          fileIn = {}
+          allFiles = os.listdir(inputFile)
+          for sampleName, sample in self._samples.iteritems():
+            fileIn[sampleName] = ROOT.TFile.Open(inputFile+'/plots_%s_ALL_%s.root' % (self._tag, sampleName))
+            if not fileIn[sampleName]:
+              raise RuntimeError('Input file for sample ' + sampleName + ' missing')
+          if os.path.exists(inputFile+'/plots_total.root'):
+            fileIn['total'] = ROOT.TFile.Open(inputFile+'/plots_total.root')
+              
+        else:
+          fileIn = ROOT.TFile(inputFile, "READ")
+
         #---- save one TCanvas for every cut and every variable
         for cutName in self._cuts :
           print "cut =", cutName, "::", cuts[cutName]
           for variableName, variable in self._variables.iteritems():
-            if not fileIn.GetDirectory(cutName+"/"+variableName):
+            if 'cuts' in variable and cutName not in variable['cuts']:
+              continue
+
+            if type(fileIn) is not dict and not fileIn.GetDirectory(cutName+"/"+variableName):
               continue
               
             print "variableName =", variableName
@@ -205,13 +223,18 @@ class PlotFactory:
 
             nexpected = 0
 
-            for sampleName, sample in self._samples.iteritems():
+            for sampleName, plotdef in plot.iteritems():
               if 'samples' in variable and sampleName not in variable['samples']:
                 continue
+
+              sample = self._samples[sampleName]
                 
               shapeName = cutName+"/"+variableName+'/histo_' + sampleName
-              print '     -> shapeName = ', shapeName,
-              histo = fileIn.Get(shapeName)
+              print '     -> shapeName = ', shapeName
+              if type(fileIn) is dict:
+                histo = fileIn[sampleName].Get(shapeName)
+              else:
+                histo = fileIn.Get(shapeName)
               print ' --> ', histo
               histos[sampleName] = histo.Clone('new_histo_' + sampleName + '_' + cutName + '_' + variableName)                      
               
@@ -221,18 +244,18 @@ class PlotFactory:
 
               # allow arbitrary scaling in MC (and DATA??), if needed
               # for example to "see" a signal
-              if 'scale' in plot[sampleName].keys() : 
-                histos[sampleName].Scale(plot[sampleName]['scale'])
-                #print " >> scale ", sampleName, " to ", plot[sampleName]['scale']
+              if 'scale' in plotdef.keys() : 
+                histos[sampleName].Scale(plotdef['scale'])
+                #print " >> scale ", sampleName, " to ", plotdef['scale']
 
               # apply cut dependent scale factors
               # for example when plotting different phase spaces
-              if 'cuts' in plot[sampleName].keys() : 
-                if cutName in plot[sampleName]['cuts'] :
-                  histos[sampleName].Scale( float( plot[sampleName]['cuts'][cutName] ) )
+              if 'cuts' in plotdef.keys() : 
+                if cutName in plotdef['cuts'] :
+                  histos[sampleName].Scale( float( plotdef['cuts'][cutName] ) )
      
 
-              if plot[sampleName]['isData'] == 1 :  
+              if plotdef['isData'] == 1 :  
                 if variable['divideByBinWidth'] == 1:
                   histos[sampleName].Scale(1,"width")
                   thsData.Add(histos[sampleName])
@@ -242,16 +265,16 @@ class PlotFactory:
 
 
               # data style
-              if plot[sampleName]['isData'] == 1 :
-                #print ' plot[', sampleName, '][color] = ' , plot[sampleName]['color']
-                histos[sampleName].SetMarkerColor(plot[sampleName]['color'])
+              if plotdef['isData'] == 1 :
+                #print ' plot[', sampleName, '][color] = ' , plotdef['color']
+                histos[sampleName].SetMarkerColor(plotdef['color'])
                 histos[sampleName].SetMarkerSize(1)
                 histos[sampleName].SetMarkerStyle(20)
-                histos[sampleName].SetLineColor(plot[sampleName]['color'])
+                histos[sampleName].SetLineColor(plotdef['color'])
                 
                 # blind data
-                if 'isBlind' in plot[sampleName].keys() :
-                  if plot[sampleName]['isBlind'] == 1 :
+                if 'isBlind' in plotdef.keys() :
+                  if plotdef['isBlind'] == 1 :
                     for iBin in range(1, histos[sampleName].GetNbinsX()+1):
                       histos[sampleName].SetBinContent(iBin, 0)
                       histos[sampleName].SetBinError  (iBin, 0)
@@ -275,8 +298,8 @@ class PlotFactory:
                     tgrData_vx.append(  histos[sampleName].GetBinCenter (iBin))
                     tgrData_evx.append( histos[sampleName].GetBinWidth (iBin) / 2.)                  
                     tgrData_vy.append(  histos[sampleName].GetBinContent (iBin))
-                    #print " plot[", sampleName, "].keys() = ", plot[sampleName].keys()
-                    if ('isSignal' not in plot[sampleName].keys() or plot[sampleName]['isSignal'] != 3) and not ('isBlind' in plot[sampleName].keys() and plot[sampleName]['isBlind'] == 1) :
+                    #print " plot[", sampleName, "].keys() = ", plotdef.keys()
+                    if ('isSignal' not in plotdef.keys() or plotdef['isSignal'] != 3) and not ('isBlind' in plotdef.keys() and plotdef['isBlind'] == 1) :
                       if variable['divideByBinWidth'] == 1:
                         tgrData_evy_up.append( self.GetPoissError(histos[sampleName].GetBinContent (iBin) * histos[sampleName].GetBinWidth (iBin) , 0, 1) / histos[sampleName].GetBinWidth (iBin) )
                         tgrData_evy_do.append( self.GetPoissError(histos[sampleName].GetBinContent (iBin) * histos[sampleName].GetBinWidth (iBin) , 1, 0) / histos[sampleName].GetBinWidth (iBin) )
@@ -292,7 +315,7 @@ class PlotFactory:
                     tgrData_vx[iBin-1] = (  histos[sampleName].GetBinCenter (iBin))
                     tgrData_evx.append( histos[sampleName].GetBinWidth (iBin) / 2.)                  
                     tgrData_vy[iBin-1] += histos[sampleName].GetBinContent (iBin)
-                    if 'isSignal' not in plot[sampleName].keys() or plot[sampleName]['isSignal'] == 3 :
+                    if 'isSignal' not in plotdef.keys() or plotdef['isSignal'] == 3 :
                       if variable['divideByBinWidth'] == 1:
                         tgrData_evy_up[iBin-1] = SumQ ( tgrData_evy_up[iBin-1], self.GetPoissError(histos[sampleName].GetBinContent (iBin) * histos[sampleName].GetBinWidth (iBin) , 0, 1) / histos[sampleName].GetBinWidth (iBin))
                         tgrData_evy_do[iBin-1] = SumQ ( tgrData_evy_do[iBin-1], self.GetPoissError(histos[sampleName].GetBinContent (iBin) * histos[sampleName].GetBinWidth (iBin) , 1, 0) / histos[sampleName].GetBinWidth (iBin))
@@ -303,24 +326,24 @@ class PlotFactory:
                     
 
               # MC style
-              if plot[sampleName]['isData'] == 0 :
+              if plotdef['isData'] == 0 :
                 # only background "filled" histogram
-                if plot[sampleName]['isSignal'] == 0:
+                if plotdef['isSignal'] == 0:
                   #histos[sampleName].SetFillStyle(1001)
-                  #histos[sampleName].SetFillColorAlpha(plot[sampleName]['color'], 0.5)
-                  #histos[sampleName].SetFillColor(plot[sampleName]['color'])
-                  #histos[sampleName].SetLineColor(plot[sampleName]['color']+1)
-                  histos[sampleName].SetFillColor(plot[sampleName]['color'])
+                  #histos[sampleName].SetFillColorAlpha(plotdef['color'], 0.5)
+                  #histos[sampleName].SetFillColor(plotdef['color'])
+                  #histos[sampleName].SetLineColor(plotdef['color']+1)
+                  histos[sampleName].SetFillColor(plotdef['color'])
                   histos[sampleName].SetFillStyle(3001)
                 else :
                   histos[sampleName].SetFillStyle(0)
                   histos[sampleName].SetLineWidth(2)
              
-                histos[sampleName].SetLineColor(plot[sampleName]['color'])
+                histos[sampleName].SetLineColor(plotdef['color'])
                 # scale to luminosity if MC
                 #histos[sampleName].Scale(self._lumi)  ---> NO! They are already scaled to luminosity in mkShape!
                 
-                if plot[sampleName]['isSignal'] == 1 :
+                if plotdef['isSignal'] == 1 :
                   if variable['divideByBinWidth'] == 1:
                     histos[sampleName].Scale(1,"width")
                     thsSignal.Add(histos[sampleName])
@@ -328,14 +351,14 @@ class PlotFactory:
                     thsSignal.Add(histos[sampleName])
 
 
-                elif plot[sampleName]['isSignal'] == 2 or plot[sampleName]['isSignal'] == 3 :
+                elif plotdef['isSignal'] == 2 or plotdef['isSignal'] == 3 :
                   #print "SigSup histo: ", histos[sampleName]
                   if  variable['divideByBinWidth'] == 1:
                     histos[sampleName].Scale(1,"width")
                     sigSupList.append(histos[sampleName])
                   else:
                     sigSupList.append(histos[sampleName])
-                  if plot[sampleName]['isSignal'] == 3 :
+                  if plotdef['isSignal'] == 3 :
                     #print "sigForAdditionalRatio histo: ", histos[sampleName]
                     sigForAdditionalRatioList[sampleName] = histos[sampleName]
                     sigForAdditionalDifferenceList[sampleName] = histos[sampleName]
@@ -386,7 +409,7 @@ class PlotFactory:
                   #for iBin in range(1, histos[sampleName].GetNbinsX()+1):
                     #tgrMC_vy.append(0.)
                 # fill the reference distribution, and add each "sample" that is not "signal"
-                #if plot[sampleName]['isSignal'] == 0:
+                #if plotdef['isSignal'] == 0:
                   #for iBin in range(1, histos[sampleName].GetNbinsX()+1):
                     #tgrMC_vy[iBin-1] += histos[sampleName].GetBinContent (iBin)
                  
@@ -414,13 +437,19 @@ class PlotFactory:
                     else:
                       shapeNameUp = cutName+"/"+variableName+'/histo_' + sampleName+"_"+nuisanceName+"Up"
                     #print "loading shape variation", shapeNameUp
-                    histoUp = fileIn.Get(shapeNameUp)
+                    if type(fileIn) is dict:
+                      histoUp = fileIn[sampleName].Get(shapeNameUp)
+                    else:
+                      histoUp = fileIn.Get(shapeNameUp)
                     if 'name' in nuisance:
                       shapeNameDown = cutName+"/"+variableName+'/histo_' + sampleName+"_"+nuisance['name']+"Down"
                     else:
                       shapeNameDown = cutName+"/"+variableName+'/histo_' + sampleName+"_"+nuisanceName+"Down"
                     #print "loading shape variation", shapeNameDown
-                    histoDown = fileIn.Get(shapeNameDown)
+                    if type(fileIn) is dict:
+                      histoUp = fileIn[sampleName].Get(shapeNameDown)
+                    else:
+                      histoDown = fileIn.Get(shapeNameDown)
 
                     if histoUp == None:
                       if 'all' in nuisance.keys() and nuisance ['all'] == 1 : # for all samples
@@ -546,26 +575,26 @@ class PlotFactory:
                                 #print "Warning! No", nuisanceName, " down variation for", sampleName, ' of kind lnN'
                   
                   
-                  if 'scale' in plot[sampleName].keys() : 
+                  if 'scale' in plotdef.keys() : 
                     if histoDown != None:  
                       #print " histoDown integral = ", histoDown.Integral()
-                      histoDown.Scale(plot[sampleName]['scale'])
-                      #print " ---> plot[", sampleName, "]['scale'] = ", plot[sampleName]['scale']
+                      histoDown.Scale(plotdef['scale'])
+                      #print " ---> plot[", sampleName, "]['scale'] = ", plotdef['scale']
                       #print " --> histoDown integral = ", histoDown.Integral()
                       
                     if histoUp != None:  
-                      histoUp.Scale(plot[sampleName]['scale'])
+                      histoUp.Scale(plotdef['scale'])
                                  
 
                   # apply cut dependent scale factors
                   # for example when plotting different phase spaces
-                  if 'cuts' in plot[sampleName].keys() : 
-                    if cutName in plot[sampleName]['cuts'] :
+                  if 'cuts' in plotdef.keys() : 
+                    if cutName in plotdef['cuts'] :
                       if histoDown != None:  
-                        #print " rescaling: ", sampleName, " - ", cutName, " = ", plot[sampleName]['cuts'][cutName]
-                        histoDown.Scale( float(plot[sampleName]['cuts'][cutName]) )
+                        #print " rescaling: ", sampleName, " - ", cutName, " = ", plotdef['cuts'][cutName]
+                        histoDown.Scale( float(plotdef['cuts'][cutName]) )
                       if histoUp != None:  
-                        histoUp.Scale( float(plot[sampleName]['cuts'][cutName]) )
+                        histoUp.Scale( float(plotdef['cuts'][cutName]) )
 
                   if variable["divideByBinWidth"] == 1:
                     if histoUp != None:
@@ -587,8 +616,8 @@ class PlotFactory:
                     for iBin in range(1, histos[sampleName].GetNbinsX()+1):
                       nuisances_vy_do[nuisanceName].append(0.)
                   # get the background sum
-                  if plot[sampleName]['isSignal'] == 0:   # ---> add the signal too????? See ~ 20 lines below
-                    #print "plot[", sampleName, "]['isSignal'] == ", plot[sampleName]['isSignal']
+                  if plotdef['isSignal'] == 0:   # ---> add the signal too????? See ~ 20 lines below
+                    #print "plot[", sampleName, "]['isSignal'] == ", plotdef['isSignal']
                     for iBin in range(1, histos[sampleName].GetNbinsX()+1):
                       if histoUp != None:
                         #print " nuisanceName[", iBin, "] = ", nuisanceName, " sampleName = ", sampleName, " histoUp.GetBinContent (", iBin, ") = ", histoUp.GetBinContent (iBin), \
@@ -646,13 +675,15 @@ class PlotFactory:
             # and now  let's add the signal on top of the background stack 
             # It is important to do this after setting (without signal) tgrMC_vy
             #
-            for sampleName, sample in self._samples.iteritems():
+            for sampleName, plotdef in plot.iteritems():
               if 'samples' in variable and sampleName not in variable['samples']:
                 continue
+
+              sample = self._samples[sampleName]
             
               # MC style
-              if plot[sampleName]['isData'] == 0 :
-                if plot[sampleName]['isSignal'] == 1 :
+              if plotdef['isData'] == 0 :
+                if plotdef['isSignal'] == 1 :
                   thsBackground.Add(histos[sampleName])
 
             #
@@ -752,11 +783,17 @@ class PlotFactory:
             # from the histogram itself
             #
             special_shapeName = cutName+"/"+variableName+'/histo_total' 
-            histo_total = fileIn.Get(special_shapeName)
+            if type(fileIn) is dict:
+              if 'total' in fileIn:
+                histo_total = fileIn['total'].Get(special_shapeName)
+              else:
+                histo_total = None
+            else:
+              histo_total = fileIn.Get(special_shapeName)
+
             if variable['divideByBinWidth'] == 1:
               histo_total.Scale(1,"width")
             print ' --> ', histo_total
-
             
             if len(mynuisances.keys()) != 0:
               tgrMC = ROOT.TGraphAsymmErrors()  
@@ -855,11 +892,13 @@ class PlotFactory:
             minYused = 1.
             maxYused = 1.
             
-            for sampleName, sample in self._samples.iteritems():
+            for sampleName, plotdef in plot.iteritems():
               if 'samples' in variable and sampleName not in variable['samples']:
                 continue
-            
-              if plot[sampleName]['isData'] == 1 :
+
+              sample = self._samples[sampleName]
+
+              if plotdef['isData'] == 1 :
                 histos[sampleName].Draw("p")
                 minXused = histos[sampleName].GetXaxis().GetBinLowEdge(1)
                 maxXused = histos[sampleName].GetXaxis().GetBinUpEdge(histos[sampleName].GetNbinsX())
@@ -970,10 +1009,10 @@ class PlotFactory:
             if tgrData.GetN() != 0:
               tgrData.Draw("P0")
             else : # never happening if at least one data histogram is provided
-              for sampleName, sample in self._samples.iteritems():
+              for sampleName, plotdef in plot.iteritems():
                 if 'samples' in variable and sampleName not in variable['samples']:
                   continue
-                if plot[sampleName]['isData'] == 1 :
+                if plotdef['isData'] == 1 :
                   histos[sampleName].Draw("p same")
 
             #---- the Legend
@@ -983,23 +1022,27 @@ class PlotFactory:
             tlegend.SetTextSize(0.035)
             tlegend.SetLineColor(0)
             tlegend.SetShadowColor(0)
-            reversedSamplesItems = self._samples.items()
-            reversedSamplesItems.reverse()
-            reversedSamples = OrderedDict(reversedSamplesItems)
+            reversedSampleNames = self._samples.keys()
+            reversedSampleNames.reverse()
             
             if len(groupPlot.keys()) == 0:
-              for sampleName, sample in reversedSamples.iteritems():
-                if plot[sampleName]['isData'] == 0 :
-                  if 'nameHR' in plot[sampleName].keys() :
-                    if plot[sampleName]['nameHR'] != '' :
+              for sampleName in reversedSampleNames:
+                try:
+                  plotdef = plot[sampleName]
+                except KeyError:
+                  continue
+
+                if plotdef['isData'] == 0 :
+                  if 'nameHR' in plotdef.keys() :
+                    if plotdef['nameHR'] != '' :
                       if self._showIntegralLegend == 0 :
-                        tlegend.AddEntry(histos[sampleName], plot[sampleName]['nameHR'], "F")
+                        tlegend.AddEntry(histos[sampleName], plotdef['nameHR'], "F")
                       else :
                         if variable["divideByBinWidth"] == 1:
                           nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX()+1,"width") 
                         else:
                           nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX()+1)
-                        tlegend.AddEntry(histos[sampleName], plot[sampleName]['nameHR'] + " [" +  str(round(nevents,1)) + "]", "F")
+                        tlegend.AddEntry(histos[sampleName], plotdef['nameHR'] + " [" +  str(round(nevents,1)) + "]", "F")
                   else :
                     if self._showIntegralLegend == 0 :
                       tlegend.AddEntry(histos[sampleName], sampleName, "F")
@@ -1010,17 +1053,22 @@ class PlotFactory:
                         nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX()+1)
                       tlegend.AddEntry(histos[sampleName], sampleName + " [" +  str(round(nevents,1)) + "]", "F")
                
-              for sampleName, sample in reversedSamples.iteritems():
-                if plot[sampleName]['isData'] == 1 :
-                  if 'nameHR' in plot[sampleName].keys() :
+              for sampleName in reversedSampleNames:
+                try:
+                  plotdef = plot[sampleName]
+                except KeyError:
+                  continue
+
+                if plotdef['isData'] == 1 :
+                  if 'nameHR' in plotdef.keys() :
                     if self._showIntegralLegend == 0 :
-                      tlegend.AddEntry(histos[sampleName], plot[sampleName]['nameHR'], "EPL")
+                      tlegend.AddEntry(histos[sampleName], plotdef['nameHR'], "EPL")
                     else :
                       if variable["divideByBinWidth"] == 1:
                         nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX()+1,"width")
                       else:
                         nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX()+1)
-                      tlegend.AddEntry(histos[sampleName], plot[sampleName]['nameHR'] + " [" +  str(round(nevents,1)) + "]", "EPL")
+                      tlegend.AddEntry(histos[sampleName], plotdef['nameHR'] + " [" +  str(round(nevents,1)) + "]", "EPL")
                   else :
                     if self._showIntegralLegend == 0 :
                       tlegend.AddEntry(histos[sampleName], sampleName, "EPL")
@@ -1032,7 +1080,6 @@ class PlotFactory:
                       tlegend.AddEntry(histos[sampleName], sampleName + " [" +  str(round(nevents,1)) + "]", "EPL")
             
             else :
-              
               for sampleNameGroup, sampleConfiguration in groupPlot.iteritems():
                 if 'samples' in variable and len(set(sampleConfiguration['samples']) & set(variable['samples'])) == 0:
                   continue
@@ -1046,21 +1093,26 @@ class PlotFactory:
                     nevents = histos_grouped[sampleNameGroup].Integral(1,histos_grouped[sampleNameGroup].GetNbinsX()+1)
                   tlegend.AddEntry(histos_grouped[sampleNameGroup], sampleConfiguration['nameHR'] + " [" +  str(round(nevents,1)) + "]" , "F")
                
-              for sampleName, sample in reversedSamples.iteritems():
+              for sampleName in reversedSampleNames:
                 if 'samples' in variable and sampleName not in variable['samples']:
                   continue
+
+                try:
+                  plotdef = plot[sampleName]
+                except KeyError:
+                  continue
               
-                if plot[sampleName]['isData'] == 1 :
-                  if 'nameHR' in plot[sampleName].keys() :
+                if plotdef['isData'] == 1 :
+                  if 'nameHR' in plotdef.keys() :
                     if self._showIntegralLegend == 0 :
-                      tlegend.AddEntry(histos[sampleName], plot[sampleName]['nameHR'], "EPL")
+                      tlegend.AddEntry(histos[sampleName], plotdef['nameHR'], "EPL")
                     else :
                       if variable["divideByBinWidth"] == 1:
                         nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX()+1,"width")
                       else:
                         nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX()+1)
                       print " nevents [", sampleName, "] = ", nevents
-                      tlegend.AddEntry(histos[sampleName], plot[sampleName]['nameHR'] + " [" +  str(round(nevents,1)) + "]", "EPL")
+                      tlegend.AddEntry(histos[sampleName], plotdef['nameHR'] + " [" +  str(round(nevents,1)) + "]", "EPL")
                   else :
                     if self._showIntegralLegend == 0 :
                       tlegend.AddEntry(histos[sampleName], sampleName , "EPL")
@@ -1073,7 +1125,6 @@ class PlotFactory:
                       tlegend.AddEntry(histos[sampleName], sampleName + " [" +  str(round(nevents,1)) + "]", "EPL")
               
               
-                  
             if len(mynuisances.keys()) != 0:
                 if self._showIntegralLegend == 0 :
                     tlegend.AddEntry(tgrMC, "All MC", "F")

--- a/ShapeAnalysis/python/ShapeFactoryMulti.py
+++ b/ShapeAnalysis/python/ShapeFactoryMulti.py
@@ -129,10 +129,8 @@ class ShapeFactory:
         #    first create the "weights" list, if not already available 
         for sampleName, sample in self._samples.iteritems():
           print sampleName
-          if 'weights' not in sample.keys() :
-            sample['weights'] = []
-            for numSample in range(0, len(sample ['name']) ) :
-              sample['weights'].append ('1')
+          if 'weights' not in sample:
+            sample['weights'] = ['1'] * len(sample['name'])
 
           # then add the lumi scale factor, unless the tree is data
           dataTrees = []
@@ -231,7 +229,7 @@ class ShapeFactory:
           drawer.setFilter(supercut)
           drawer.setReweight(sample['weight'])
 
-          if 'weights' in sample.keys():
+          if 'weights' in sample:
             weights = sample['weights']
             print "  weights:", weights
             if len(weights) != 0 and len(weights) != len(sample['name']):
@@ -244,7 +242,7 @@ class ShapeFactory:
               drawer.setTreeReweight(it, False, w)
 
           # Set overall weights on the nuisance up/down drawers
-          for nuisanceDrawers in [drawersNuisanceUp, drawersNuisanceDown]:
+          for idir, nuisanceDrawers in enumerate([drawersNuisanceUp, drawersNuisanceDown]):
             for nuisanceName, drawersList in nuisanceDrawers.iteritems():
               if sampleName not in drawersList:
                 continue
@@ -253,7 +251,7 @@ class ShapeFactory:
   
               ndrawer = drawersList[sampleName]
               ndrawer.setFilter(supercut)
-              ndrawer.setReweight('(%s) * (%s)' % (sample['weight'], configurationNuis[0]))
+              ndrawer.setReweight('(%s) * (%s)' % (sample['weight'], configurationNuis[idir]))
   
               for it, w in enumerate(weights):
                 if w != '-':

--- a/ShapeAnalysis/python/ShapeFactoryMulti.py
+++ b/ShapeAnalysis/python/ShapeFactoryMulti.py
@@ -534,10 +534,9 @@ class ShapeFactory:
               for catsuffix in catsuffixes:
                 hTotal = ROOT.gROOT.Get(cutName + catsuffix + '/' + variableName + '/' + histoName)
 
-                print '   ', cutName + catsuffix + '/' + variableName + '/' + histoName
-  
                 # fold if needed
                 if 'fold' in variable:
+                  print '   ', cutName + catsuffix + '/' + variableName + '/' + histoName
                   print "    variable[fold] = ", variable['fold']
                   doFold = variable['fold']
                 else:
@@ -601,7 +600,7 @@ class ShapeFactory:
                     if 'kind' not in nuisance:
                       continue
 
-                    print '     ', nuisanceName
+                    #print '     ', nuisanceName
 
                     subsampleNameUp = subsampleName + '_' + nuisance['name'] + 'Up'
                     subsampleNameDown = subsampleName + '_' + nuisance['name'] + 'Down'

--- a/ShapeAnalysis/python/ShapeFactoryMulti.py
+++ b/ShapeAnalysis/python/ShapeFactoryMulti.py
@@ -68,7 +68,7 @@ class ShapeFactory:
 
 
     # _____________________________________________________________________________
-    def makeNominals(self, inputDir, outputDir, variables, cuts, samples, nuisances, supercut, number=99999):
+    def makeNominals(self, inputDir, outputDir, variables, cuts, samples, nuisances, supercut, number=99999, firstEvent=0, nevents=-1):
 
         print "======================"
         print "==== makeNominals ===="
@@ -109,8 +109,9 @@ class ShapeFactory:
         for cutName in self._cuts:
           print "cut = ", cutName, " :: ", self._cuts[cutName]
           ROOT.gROOT.mkdir(cutName)
-          for variableName in self._variables:
-            ROOT.gROOT.mkdir(cutName+"/"+variableName)
+          for variableName, variable in self._variables.iteritems():
+            if 'cuts' not in variable or cutName in variable['cuts']:
+              ROOT.gROOT.mkdir(cutName+"/"+variableName)
 
         #---- just print the variables
         print '  <variables>'
@@ -215,210 +216,6 @@ class ShapeFactory:
             
             #print " >> nuisanceName : ", nuisanceName, " -> ",    list_of_trees_to_connect  , " from ",    nuisance['folderUp'] , " / " , nuisance['folderDown'] 
 
-        ## test with LOOP: not very fast ... to be improved ...
-
-        ##---- now plot and save into output root file
-        ## - loops
-        ##    -> samples
-        ##      -> cut 
-        ##        -> variables
-        ##
-
-        ## all the histograms
-        #histos = {}       
-        #weightToPlotFormulas = {}
-        #variableToPlotFormulas = {}
-        
-        #for sampleName, sample in self._samples.iteritems():
-          
-          #print "sampleName = ", sampleName
-          ## first prepare all dummy histograms
-          #for cutName, cut in self._cuts.iteritems():
-            #for variableName, variable in self._variables.iteritems():
-
-              #numTree = 0
-              #for tree in inputs[sampleName]:      
-                ## new histogram
-                #shapeName = 'histo_' + sampleName + "_" + cutName + "_" + variableName + "_" + str(numTree)
-                ## prepare a dummy to fill
-                #histos[shapeName] = self._makeshape(shapeName,variable['range'])
-
-
-                #global_weight = sample ['weight']
-                #globalCut = "(" + cut + ") * (" + global_weight + ")"  
-
-                ## if weights vector is not given, do not apply file dependent weights
-                #if 'weights' in sample.keys() and len(sample ['weights']) != 0 :
-                  ## if weight is not given for a given root file, '-', do not apply file dependent weight for that root file
-                  #if sample ['weights'][numTree] != '-' :
-                    #globalCut = "(" + globalCut + ") * (" +  sample ['weights'][numTree] + ")" 
-
-                #weightFormulaName = 'weight_' + sampleName + '_' + cutName + '_' + variableName + '_' + str(numTree)
-                #weightToPlotFormulas[weightFormulaName] = ROOT.TTreeFormula(weightFormulaName, globalCut , tree)
-
-                #numTree += 1
-
-
-        #for sampleName, sample in self._samples.iteritems():          
-          #for variableName, variable in self._variables.iteritems():
-            #numTree = 0
-            #for tree in inputs[sampleName]:      
-              #variableFormulaName = 'weight_' + sampleName + '_' + '_' + variableName + '_' + str(numTree)
-              #variableToPlotFormulas[variableFormulaName] = ROOT.TTreeFormula(variableFormulaName, variable['name'] , tree)
-              #numTree += 1
-
-
-          
-          ## now really fill the histograms
-          #numTree = 0
-          #for tree in inputs[sampleName]:
-           
-            #print '        {0:<20} : {1:^9}'.format(sampleName,tree.GetEntries()),
-            ##print '        {0:<20} : {1:^9}'.format(sampleName,tree.GetEntries())
-            ## loop over events
-            #step = 5000
-            #nentries = tree.GetEntries()
-            
-            ## pre-filter
-            ##  to speed up
-            #tree.SetEntryList(0)
-            ## get the list
-            ##myList = ROOT.TEntryList(tree)
-            #myList = ROOT.TEntryList('myList'+'_'+str(numTree)+'_'+sampleName,"")
-            #nentriesFiltered = myList.GetN()
-            #print "      -> nentriesFiltered = ", nentriesFiltered, 
-            #tree.Draw('>> myList'+'_'+str(numTree)+'_'+sampleName , supercut, "entrylist");
-            ## apply the list
-            #tree.SetEntryList(myList)
-            #nentriesFiltered = myList.GetN()
-            #print "      -> nentriesFiltered = ", nentriesFiltered
- 
-
-            ## mild the steps
-            #while nentriesFiltered / step > 10 :
-              #step *= 10
-
-
-            ## now really looping over events
-            ##for iEvent in xrange(nentries):
-            
-            #for iEventSel in xrange(nentriesFiltered):
-              #iEvent = -1
-              #if iEventSel == 0 :
-               #iEvent = myList.GetEntry(0)
-               #iEventSel+=1
-              #else :
-               #iEvent = myList.Next()
-               #iEventSel+=1
-               #tree.GetEntry(iEvent)
-              
-              ### print event count
-              #if iEventSel > 0 and iEventSel%step == 0.:
-                #print '   >> ', iEvent, 'events processed ::', nentries, ' [', iEventSel, '(', nentriesFiltered, ')] --> %.2f' % (1. * iEventSel / nentriesFiltered * 100), ' % '
-
-              #for cutName, cut in self._cuts.iteritems():
-                ##print "cut = ", cutName, " :: ", cut
-
-                ##global_weight = sample ['weight']
-                ##globalCut = "(" + cut + ") * (" + global_weight + ")"  
-
-                ### if weights vector is not given, do not apply file dependent weights
-                ##if 'weights' in sample.keys() and len(sample ['weights']) != 0 :
-                  ### if weight is not given for a given root file, '-', do not apply file dependent weight for that root file
-                  ##if sample ['weights'][numTree] != '-' :
-                    ##globalCut = "(" + globalCut + ") * (" +  sample ['weights'][numTree] + ")" 
-
-                ##weightToPlotFormula = ROOT.TTreeFormula('blabla', globalCut , tree)
-                
-                #for variableName, variable in self._variables.iteritems():
-                  ##print "  variable[name]  = ", variable['name']
-                  ##print "  variable[range] = ", variable['range']
-                  #self._outFile.cd (cutName+"/"+variableName)
-
-                  ##variableToPlotFormula = ROOT.TTreeFormula('blabla', variable['name'] , tree)
-
-                  #shapeName = 'histo_' + sampleName + '_' + cutName + '_' + variableName + '_' + str(numTree)
-              
-                  #self._logger.debug('---'+sampleName+'---')
-                  #self._logger.debug('Formula: '+variable['name']+'>>'+shapeName)
-                  #self._logger.debug('Cut:     '+cut)
-                  #self._logger.debug('ROOTFiles:'+'\n'.join([f.GetTitle() for f in tree.GetListOfFiles()]))
-
-                  #weightFormulaName = 'weight_' + sampleName + '_' + cutName + '_' + variableName + '_' + str(numTree)
-                  #variableFormulaName = 'weight_' + sampleName + '_' + '_' + variableName + '_' + str(numTree)
-
-                  #histos[shapeName].Fill( variableToPlotFormulas[variableFormulaName].EvalInstance(), weightToPlotFormulas[weightFormulaName].EvalInstance() )
- 
-            #numTree += 1
-          
-        ##
-        ## now post filling processing
-        ## loop
-        ##  -> cut
-        ##    -> variable
-        ##      -> sample
-        #for cutName, cut in self._cuts.iteritems():
-          #for variableName, variable in self._variables.iteritems():      
-            #for sampleName, sample in self._samples.iteritems():
-              #bigName = 'histo_' + sampleName
-              #hTotal = self._makeshape(bigName,variable['range'])
-              #numTree = 0
-              #for tree in inputs[sampleName] :
-                #shapeName = 'histo_' + sampleName + "_" + cutName + "_" + variableName + "_" + str(numTree)
-                #if (numTree == 0) :
-                  #histos[shapeName].SetTitle(bigName)
-                  #histos[shapeName].SetName(bigName)
-                  #hTotal = histos[shapeName]
-                #else :
-                  #hTotal.Add(histos[shapeName])
-
-                #numTree += 1
- 
-
-              ## fold if needed
-              #doFold = 0
-              #if 'fold' in variable.keys() :
-                ##print "    variable[fold] = ", variable ['fold']
-                #doFold = variable ['fold']
-
-              #if doFold == 1 or doFold == 3 :
-                #self._FoldOverflow  (hTotal)
-              #if doFold == 2 or doFold == 3 :
-                #self._FoldUnderflow (hTotal)
-        
-        
-              ## go 1d
-              #self._outFile.cd (cutName+"/"+variableName)
-              #outputsHisto = self._h2toh1(hTotal)
-
-              ## eventually write to root file!
-              #outputsHisto.Write()              
-     
-            
-              ## prepare nuisance MC/data statistics
-              ## - uniform
-              ## - uniform method 2
-              ## - bin by bin (in selected bins)
-              #for nuisanceName, nuisance in nuisances.iteritems():
-                #if nuisanceName == 'stat' : # 'stat' has a separate treatment, it's the MC/data statistics
-                  ##print "nuisance[type] = ", nuisance ['type']
-                  #for sampleNuisName, configurationNuis in nuisance['samples'].iteritems() :
-                    #if sampleNuisName == sampleName: # check if it is the sample I'm analyzing!
-                      #if configurationNuis['typeStat'] == 'uni' :
-                        ##print "     >> uniform"
-                        ## take histogram --> outputsHisto
-                        #outputsHistoUp = outputsHisto.Clone("histo_"+sampleName+"_statUp")
-                        #outputsHistoDo = outputsHisto.Clone("histo_"+sampleName+"_statDown")
-                        ## scale up/down
-                        #self._scaleHistoStat (outputsHistoUp,  1 )
-                        #self._scaleHistoStat (outputsHistoDo, -1 )
-                        ## save the new two histograms in final root file
-                        #outputsHistoUp.Write()
-                        #outputsHistoDo.Write()
-                                 
-        ## - then disconnect the files
-        #self._disconnectInputs(inputs)
-        
         #############################################
         # Use MultiDraw to fill the plots in one go #
         #############################################
@@ -471,8 +268,9 @@ class ShapeFactory:
                 cuts[(binName, cutName)] = '(%s) && (%s)' % (binCut, cut)
 
                 ROOT.gROOT.mkdir('binned/' + binName + '/' + cutName)
-                for variableName in self._variables:
-                  ROOT.gROOT.mkdir('binned/' + binName + '/' + cutName + '/' + variableName)
+                for variableName, variable in self._variables.iteritems():
+                  if 'cuts' not in variable or cutName in variable['cuts']:
+                    ROOT.gROOT.mkdir('binned/' + binName + '/' + cutName + '/' + variableName)
           else:
             cuts = self._cuts
 
@@ -526,6 +324,9 @@ class ShapeFactory:
               if 'samples' in variable and sampleName not in variable['samples']:
                 continue
 
+              if 'cuts' in variable and cutName not in variable['cuts']:
+                continue
+
               if binName:
                 ROOT.gROOT.cd('binned/' + binName + '/' + cutName + '/' + variableName)
               else:
@@ -544,10 +345,10 @@ class ShapeFactory:
               hTotal.SetName(bigName)
 
               if hTotal.InheritsFrom(ROOT.TH2.Class()):
-                  xexpr, yexpr = ShapeFactory._splitexpr(variable['name'])
-                  drawer.addPlot2D(hTotal, xexpr, yexpr, cutFullName)
+                xexpr, yexpr = ShapeFactory._splitexpr(variable['name'])
+                drawer.addPlot2D(hTotal, xexpr, yexpr, cutFullName)
               else:
-                  drawer.addPlot(hTotal, variable['name'], cutFullName)
+                drawer.addPlot(hTotal, variable['name'], cutFullName)
 
               for nuisanceName, nuisance in applicableNuisances.iteritems():
                 if nuisanceName == 'stat' or 'kind' not in nuisance:
@@ -593,19 +394,19 @@ class ShapeFactory:
 
           # We now defined all plots for this sample - execute the drawers and fill the histograms
           print 'Start nominal histogram fill'
-          drawer.execute()
+          drawer.execute(nevents, firstEvent)
           # We don't need this drawer any more - can reduce the number of open FDs?
           del drawer
 
           for nuisanceName, drawersUpList in drawersNuisanceUp.iteritems():
             if sampleName in drawersUpList:
               print 'Start', nuisanceName + 'Up', 'histogram fill'
-              drawersUpList[sampleName].execute()
+              drawersUpList[sampleName].execute(nevents, firstEvent)
               drawersUpList.pop(sampleName)
           for nuisanceName, drawersDownList in drawersNuisanceDown.iteritems():
             if sampleName in drawersDownList:
               print 'Start', nuisanceName + 'Down', 'histogram fill'
-              drawersDownList[sampleName].execute()
+              drawersDownList[sampleName].execute(nevents, firstEvent)
               drawersDownList.pop(sampleName)
 
           print 'Postfill'
@@ -624,6 +425,9 @@ class ShapeFactory:
 
             for variableName, variable in self._variables.iteritems():
               if 'samples' in variable and sampleName not in variable['samples']:
+                continue
+
+              if 'cuts' in variable and cutName not in variable['cuts']:
                 continue
 
               print "    variable[name]  = ", variable['name']

--- a/ShapeAnalysis/scripts/mkDatacards.py
+++ b/ShapeAnalysis/scripts/mkDatacards.py
@@ -8,6 +8,7 @@ import ROOT
 import optparse
 import LatinoAnalysis.Gardener.hwwtools as hwwtools
 import logging
+import collections
 import os.path
 import shutil
 
@@ -53,11 +54,11 @@ class DatacardFactory:
           self._fileIn = ROOT.TFile(inputFile, "READ")
 
         # categorize the sample names
-        signal_ids = {} # id map of alternative_signals + cumulative_signals
+        signal_ids = collections.OrderedDict() # id map of alternative_signals + cumulative_signals
         alternative_signals = ['']
         cumulative_signals = []
         data = []
-        background_ids = {}
+        background_ids = collections.OrderedDict()
         
         # divide the list of samples among signal, background and data
         isig = 0
@@ -415,6 +416,10 @@ class DatacardFactory:
                 if nuisance['type'] != 'rateParam':
                   continue
 
+                # check if a nuisance can be skipped because not in this particular cut
+                if 'cuts' in nuisance and cutName not in nuisance['cuts']:
+                  continue
+
                 card.write(nuisance['name'].ljust(80-20))
                 card.write('rateParam'.ljust(20))
                 card.write(tagNameToAppearInDatacard.ljust(columndef))   # the bin
@@ -575,7 +580,7 @@ if __name__ == '__main__':
       for iCut in cut2del : del cuts[iCut]   
   
     # ~~~~
-    nuisances = {}
+    nuisances = collections.OrderedDict()
     if opt.nuisancesFile == None :
        print " Please provide the nuisances structure if you want to add nuisances "
        
@@ -585,7 +590,7 @@ if __name__ == '__main__':
       handle.close()
 
     # ~~~~
-    structure = {}
+    structure = collections.OrderedDict()
     if opt.structureFile == None :
        print " Please provide the datacard structure "
        exit ()

--- a/ShapeAnalysis/scripts/mkDatacards.py
+++ b/ShapeAnalysis/scripts/mkDatacards.py
@@ -9,13 +9,11 @@ import optparse
 import LatinoAnalysis.Gardener.hwwtools as hwwtools
 import logging
 import os.path
-
+import shutil
+import re
 
 # Common Tools & batch
 from LatinoAnalysis.Tools.commonTools import *
-
-
-
 
 
 # ----------------------------------------------------- DatacardFactory --------------------------------------
@@ -26,35 +24,11 @@ class DatacardFactory:
     # _____________________________________________________________________________
     def __init__(self):
       
-        variables = {}
-        self._variables = variables
-
-        cuts = {}
-        self._cuts = cuts
-
-        samples = {}
-        self._samples = samples
-
-        ## list of [processes]  
-        self.processes = []
-        ## list of [signal processes]
-        self.signals = []
-        ## list of [background processes]
-        self.backgrounds = []
-
-        ## list of [alternative signal processes] (Different mass points, different models...) --> isSignal = 2
-        self.alternative_signals = []
-        ## list of [cumulative signal processes] (Standard approach) --> isSignal = 1
-        self.cumulative_signals = []
-        ## list of [signal processes] --> isSignal = 1 or isSignal = 2
-        self.all_signals = []
-        ## list of [background processes]
-        self.all_backgrounds = []
-
-        ## data
-        self.data = []        
-        ## list of [(name of uncert, type of nuisance, list of samples affected, with value, additional value [in case of gmN])]
-        self.systs   = []
+        self._variables = {}
+        self._cuts = {}
+        self._samples = {}
+        self._fileIn = None
+        self._skipMissingNuisance = False
 
     # _____________________________________________________________________________
     # a datacard for each "cut" and each "variable" will be produced, in separate sub-folders, names after "cut/variable"
@@ -69,52 +43,73 @@ class DatacardFactory:
         self._samples   = samples
         self._cuts      = cuts
 
-        self._outputDirDatacard = outputDirDatacard
+        if os.path.isdir(inputFile):
+          # ONLY COMPATIBLE WITH OUTPUTS MERGED TO SAMPLE LEVEL!!
+          self._fileIn = {}
+          allFiles = os.listdir(inputFile)
+          for sampleName, sample in self._samples.iteritems():
+            self._fileIn[sampleName] = ROOT.TFile.Open(inputFile+'/plots_%s_ALL_%s.root' % (self._tag, sampleName))
+            if not self._fileIn[sampleName]:
+              raise RuntimeError('Input file for sample ' + sampleName + ' missing')
+        else:
+          self._fileIn = ROOT.TFile(inputFile, "READ")
 
-        self._fileIn = ROOT.TFile(inputFile, "READ")
+        # categorize the sample names
+        signal_ids = {} # id map of alternative_signals + cumulative_signals
+        alternative_signals = ['']
+        cumulative_signals = []
+        data = []
+        background_ids = {}
         
         # divide the list of samples among signal, background and data
+        isig = 0
+        ibkg = 1
         for sampleName, sample in self._samples.iteritems():
-          if structureFile[sampleName]['isSignal'] == 1 or structureFile[sampleName]['isSignal'] == 2:
-            self.all_signals.append(sampleName)
+          if structureFile[sampleName]['isSignal'] != 0:
+            signal_ids[sampleName] = isig
+            isig -= 1
           if structureFile[sampleName]['isSignal'] == 2 :
-            self.alternative_signals.append(sampleName)
+            alternative_signals.append(sampleName)
           if structureFile[sampleName]['isSignal'] == 1 :
-            self.cumulative_signals.append(sampleName)
+            cumulative_signals.append(sampleName)
           if structureFile[sampleName]['isData'] == 1 :
-            self.data.append(sampleName)
+            data.append(sampleName)
           if structureFile[sampleName]['isSignal'] == 0 and structureFile[sampleName]['isData'] == 0:
-            self.all_backgrounds.append(sampleName)
-        self.alternative_signals.append("")
+            background_ids[sampleName] = ibkg
+            ibkg += 1
 
-        if not os.path.isdir (self._outputDirDatacard + "/") :
-          os.mkdir (self._outputDirDatacard + "/")
+        print "Number of Signals:             " + str(len(signal_ids))
+        print "Number of Alternative Signals: " + str(len(alternative_signals) - 1)
+        print "Number of Cumulative Signals:  " + str(len(cumulative_signals))
+        print "Number of Backgrounds:         " + str(len(background_ids))
 
-        # loop over cuts  
-        for cutName in self._cuts :
+        if not os.path.isdir(outputDirDatacard + "/") :
+          os.mkdir(outputDirDatacard + "/")
+
+        # loop over cuts. One directory per cut will be created
+        for cutName in self._cuts:
           print "cut = ", cutName, " :: ", cuts[cutName]
-          os.system ("rm -rf " + self._outputDirDatacard + "/" + cutName) 
-          os.mkdir (self._outputDirDatacard + "/" + cutName)
+          try:
+            shutil.rmtree(outputDirDatacard + "/" + cutName)
+          except OSError:
+            pass
+          os.mkdir(outputDirDatacard + "/" + cutName)
           
           #
           # prepare the signals and background list of samples
           # after removing the ones not to be used in this specific phase space
           #
-          self.signals = []
-          for sampleName in self.all_signals :
-            if 'removeFromCuts' in structureFile[sampleName].keys() and cutName in structureFile[sampleName]['removeFromCuts'] :
-              # remove from the list
-              print ' remove ', sampleName, ' from ', cutName
-            else :
-              self.signals.append (sampleName)
+          cut_signals = []
+          cut_backgrounds = []
+          for snameList, idmap in [(cut_signals, signal_ids), (cut_backgrounds, background_ids)]:
+            for sampleName in idmap:
+              if 'removeFromCuts' in structureFile[sampleName] and cutName in structureFile[sampleName]['removeFromCuts']:
+                # remove from the list
+                print ' remove ', sampleName, ' from ', cutName
+              else:
+                snameList.append(sampleName)
 
-          self.backgrounds = []
-          for sampleName in self.all_backgrounds :
-            if 'removeFromCuts' in structureFile[sampleName].keys() and cutName in structureFile[sampleName]['removeFromCuts'] :
-              # remove from the list
-              print ' remove ', sampleName, ' from ', cutName
-            else :
-              self.backgrounds.append (sampleName)
+          print "  sampleNames = ", cut_signals + cut_backgrounds
           
           # loop over variables
           for variableName, variable in self._variables.iteritems():
@@ -126,766 +121,372 @@ class DatacardFactory:
             # e.g.    hww2l2v_13TeV_of0j
             #         to be defined in cuts.py
 
-            os.mkdir (self._outputDirDatacard + "/" + cutName + "/" + variableName) 
-            os.mkdir (self._outputDirDatacard + "/" + cutName + "/" + variableName + "/shapes/") # and the folder for the root files 
+            os.mkdir(outputDirDatacard + "/" + cutName + "/" + variableName) 
+            os.mkdir(outputDirDatacard + "/" + cutName + "/" + variableName + "/shapes/") # and the folder for the root files 
 
-            self._outFile = ROOT.TFile.Open( self._outputDirDatacard + "/" + cutName + "/" + variableName + "/shapes/histos_" + tagNameToAppearInDatacard + ".root", 'recreate')
-            ROOT.TH1.SetDefaultSumw2(True)
-        
+            self._outFile = ROOT.TFile.Open(outputDirDatacard + "/" + cutName + "/" + variableName + "/shapes/histos_" + tagNameToAppearInDatacard + ".root", 'recreate')
+                    
             # prepare yields
             yieldsSig  = {}
             yieldsBkg  = {}
             yieldsData = {}
 
             # Bin to be killed
-            #killBinSig = {}  
-            #killBinBkg = {}  
-            
-            for sampleName in self.signals:
-              shapeName = cutName+"/"+variableName+'/histo_' + sampleName
-              histo = self._fileIn.Get(shapeName)
-             # print " shapeName = ", shapeName     
-             # print sampleName     
-             # if 'removeNegNomVal' in structureFile[sampleName] and structureFile[sampleName]['removeNegNomVal'] :
-             #   for iBin in range(0,histo.GetNbinsX()+2) :
-             #     BinContent = histo.GetBinContent(iBin)
-             #     if BinContent < 0.1 and not BinContent == 0:
-             #       print 'Killing Bin :' , sampleName , iBin , BinContent
-             #       if not sampleName in killBinSig : killBinSig[sampleName] = []
-             #       killBinSig[sampleName].append(iBin)
-             #       histo.SetBinContent(iBin,0.)
-              # get the integral == rate from histogram
-              yieldsSig[sampleName] = histo.Integral()
-             # print yieldsSig[sampleName]
-              self._outFile.cd()
-              histo.Write()
+            #killBinSig = {}
+            #killBinBkg = {}
 
-            for sampleName in self.backgrounds:
-              shapeName = cutName+"/"+variableName+'/histo_' + sampleName
-              histo = self._fileIn.Get(shapeName)
-              # get the integral == rate from histogram
-            #  print " shapeName = ", shapeName
-            #  if 'removeNegNomVal' in structureFile[sampleName] and structureFile[sampleName]['removeNegNomVal'] :
-            #    for iBin in range(0,histo.GetNbinsX()+2) :
-            #      BinContent = histo.GetBinContent(iBin)
-            #      if BinContent < 0.3 and not BinContent == 0:
-            #        print 'Killing Bin :' , sampleName , iBin , BinContent
-            #        if not sampleName in killBinBkg : killBinBkg[sampleName] = []
-            #        killBinBkg[sampleName].append(iBin)
-            #        histo.SetBinContent(iBin,0.)
-              yieldsBkg[sampleName] = histo.Integral()
-            #  print yieldsBkg[sampleName]
-              self._outFile.cd()
-              histo.Write()
-           
-            #print killBinSig
-            #print killBinBkg 
-            #exit()
-            for sampleName in self.data:
-              shapeName = cutName+"/"+variableName+'/histo_' + sampleName
-              histo = self._fileIn.Get(shapeName)
-              # get the integral == rate from histogram
-              yieldsData['data'] = histo.Integral() # data is data!
-              histo.SetName("histo_Data")
-              self._outFile.cd()
-              histo.Write()
-                        
-            # Loop over alternative signal samples
-            alternativeSignalName = ""  
-            if len(self.alternative_signals) != 0:
-                for signalName in self.alternative_signals :
-                    if signalName != '' and signalName not in self.signals:
-                        continue
-                   
-                    print "Alternative signal: " + str(signalName)
-                    alternativeSignalName  = str(signalName)
-                    alternativeSignalTitle = ""
-                    if alternativeSignalName != "":
-                        alternativeSignalTitle = "_" + str(signalName)
-
-                    cumulative_signals = [name for name in self.cumulative_signals if name in self.signals]
-
-                    # start creating the datacard 
-                    cardPath = self._outputDirDatacard + "/" + cutName + "/" + variableName  + "/datacard" + alternativeSignalTitle + ".txt"
-                    print 'Writing to ' + cardPath 
-                    card = open( cardPath ,"w")
-                    card.write('## Shape input card\n')
-        
-                    card.write('imax 1 number of channels\n')
-                    card.write('jmax * number of background\n')
-                    card.write('kmax * number of nuisance parameters\n') 
+            for snameList, yields in [(cut_signals, yieldsSig), (cut_backgrounds, yieldsBkg), (data, yieldsData)]:
+              for sampleName in snameList:
+                histo = self._getHisto(cutName, variableName, sampleName)
+                histo.SetDirectory(self._outFile)
+  
+                # get the integral == rate from histogram
+                if structureFile[sampleName]['isData'] == 1:
+                  yields['data'] = histo.Integral()
+                  histo.SetName("histo_Data")
+                else:
+#                  if 'removeNegNomVal' in structureFile[sampleName] and structureFile[sampleName]['removeNegNomVal'] :
+#                    for iBin in range(0,histo.GetNbinsX()+2) :
+#                      BinContent = histo.GetBinContent(iBin)
+#                      if BinContent < 0.1 and not BinContent == 0:
+#                        print 'Killing Bin :' , sampleName , iBin , BinContent
+#                        if not sampleName in killBinSig : killBinSig[sampleName] = []
+#                        killBinSig[sampleName].append(iBin)
+#                        histo.SetBinContent(iBin,0.)
                     
-                    card.write('-'*100+'\n')
-                    card.write('bin         %s' % tagNameToAppearInDatacard+'\n')
-                    if len(self.data) == 0:
-                        self._logger.warning( 'no data, no fun! ')
-                        #raise RuntimeError('No Data found!')
-                        yieldsData['data'] = 0
+                  yields[sampleName] = histo.Integral()
+  
+                self._outFile.cd()
+                histo.Write()
 
-                    card.write('observation %.0f\n' % yieldsData['data'])
-            
-                    card.write('shapes  *           * '+
-                               'shapes/histos_' + tagNameToAppearInDatacard + ".root" +
-                               '     histo_$PROCESS histo_$PROCESS_$SYSTEMATIC' + '\n')
-            
-                    card.write('shapes  data_obs           * '+
-                               'shapes/histos_' + tagNameToAppearInDatacard + ".root" +
-                               '     histo_Data' + '\n')
-            
-                    #   shapes  *           * shapes/hww-19.36fb.mH125.of_vh2j_shape_mll.root     histo_$PROCESS histo_$PROCESS_$SYSTEMATIC
-                    #   shapes  data_obs    * shapes/hww-19.36fb.mH125.of_vh2j_shape_mll.root     histo_Data
-
-            
-                    print "Number of Signals:             " + str(len(self.signals))
-                    print "Number of Alternative Signals: " + str(len(self.alternative_signals) - 1)
-                    print "Number of Cumulative Signals:  " + str(len(cumulative_signals))
-                    print "Number of Backgrounds:         " + str(len(self.backgrounds))
-                    
-                    if alternativeSignalName == "" :
-                        totalNumberSamples = len(cumulative_signals) + len(self.backgrounds)
-                    else :
-                        totalNumberSamples = len(cumulative_signals) + len(self.backgrounds) + 1
-                    columndef = 30
-
-                    # adapt column length to long bin names            
-                    if len(tagNameToAppearInDatacard) >= (columndef - 5) :
-                        columndef = len(tagNameToAppearInDatacard) + 7
-            
-                    #print " columndef = ", columndef
-                    #print " len(tagNameToAppearInDatacard)  = ", len(tagNameToAppearInDatacard) 
-                    #print " tagNameToAppearInDatacard  = ", tagNameToAppearInDatacard
-            
-            
-                    card.write('bin'.ljust(80) + ''.join( [tagNameToAppearInDatacard.ljust(columndef) * totalNumberSamples])+'\n')
-                    #card.write('bin'.ljust(80) + ''.join( [tagNameToAppearInDatacard.ljust(columndef) for iterator in range(totalNumberSamples) ])+'\n')
-            
-                    card.write('process'.ljust(80))
-                    if alternativeSignalName == "" :
-                        card.write(''.join([name.ljust(columndef) for name in cumulative_signals]))
-                    else :
-                        card.write(alternativeSignalName.ljust(columndef))
-                        card.write(''.join([name.ljust(columndef) for name in cumulative_signals]))
-                        
-                    card.write(''.join([name.ljust(columndef) for name in self.backgrounds]))
-                    card.write('\n')
-
-                    card.write('process'.ljust(80))
-                    if alternativeSignalName == "" :
-                        card.write(''.join([('%d' % -iSample   ).ljust(columndef) for iSample in range(len(cumulative_signals)) ]))
-                    else :
-                        card.write(''.join([('%d' % -iSample   ).ljust(columndef) for iSample in range(1 + len(cumulative_signals)) ]))
-                    card.write(''.join([('%d' % (iSample+1)).ljust(columndef) for iSample in range(len(self.backgrounds)) ]))
-                    card.write('\n')
-
-                    card.write('rate'.ljust(80))
-                    if alternativeSignalName != "" :
-                        for name in self.alternative_signals :
-                            if name in yieldsSig and name == alternativeSignalName :
-                                card.write(('%-.4f' % yieldsSig[name]).ljust(columndef))
-
-                    for name in cumulative_signals :
-                        if name in yieldsSig:
-                            card.write(('%-.4f' % yieldsSig[name]).ljust(columndef))
-                            
-                    card.write(''.join([('%-.4f' % yieldsBkg[name]).ljust(columndef) for name in self.backgrounds]))
-                    card.write('\n')
-               
-                    #bin                                      of_vh2j      of_vh2j    
-                    #process                                      ggH         ggWW    
-                    #process                                        0            1    
-                    #rate                                      1.1234       2.3456
-
-                    card.write('-'*100+'\n')
-
-                    # add nuisances
-            
-                    # first the lnN nuisances
-                    for nuisanceName, nuisance in nuisances.iteritems():
-              
-                        # check if a nuisance can be skipped because not in this particular cut
-                        use_this_nuisance = False
-                        if  'cuts' in nuisance.keys() :
-                            for Cuts_where_to_use_nuisance  in   nuisance['cuts'] :
-                                if Cuts_where_to_use_nuisance == cutName :
-                                    # use this niusance
-                                    use_this_nuisance = True
-                        else :
-                            # default is use the nuisance everywhere
-                            use_this_nuisance = True 
-              
-                        if use_this_nuisance :
-               
-                            if nuisanceName != 'stat' : # 'stat' has a separate treatment, it's the MC/data statistics
+            # Loop over alternative signal samples. One card per signal (there is always at least one entry (""))
+            for signalName in alternative_signals:
+              if signalName == '':
+                signals = [name for name in cumulative_signals if name in cut_signals]
+              else:
+                if signalName not in cut_signals:
+                  continue
                   
-                                if 'type' in nuisance.keys() : # some nuisances may not have "type" ... why?
-                                    #print "nuisance[type] = ", nuisance ['type']
-                                    if nuisance ['type'] == 'lnN' or nuisance ['type'] == 'lnU' :
-                                        card.write((nuisance['name']).ljust(80-20))
-                                        card.write((nuisance['type']).ljust(20))
-                                        if 'all' in nuisance.keys() and nuisance ['all'] == 1 : # for all samples
-                                            #card.write(''.join([('%-.4f' % nuisance['value']).ljust(columndef) for name in self.signals    ]))
-                                            #card.write(''.join([('%-.4f' % nuisance['value']).ljust(columndef) for name in self.backgrounds ))
-                                            if alternativeSignalName == "" :
-                                                card.write(''.join([(' %s ' % nuisance['value']).ljust(columndef) for name in cumulative_signals]))
-                                            else :
-                                                for name in self.alternative_signals :
-                                                    if name == alternativeSignalName :
-                                                        card.write(''.join([(' %s ' % nuisance['value']).ljust(columndef) ]))
-                                                for name in cumulative_signals :
-                                                    card.write(''.join([(' %s ' % nuisance['value']).ljust(columndef) ]))
+                signals = [signalName] + [name for name in cumulative_signals if name in cut_signals]
 
-                                            card.write(''.join([(' %s ' % nuisance['value']).ljust(columndef) for name in self.backgrounds ]))
-                                            card.write('\n')
-                                        else :
-                                            # apply only to selected samples
-                                            if alternativeSignalName == "" :
-                                                for sampleName in cumulative_signals:
-                                                    if sampleName in nuisance['samples'].keys() :
-                                                        #card.write(('%-.4f' % nuisance['samples'][sampleName]).ljust(columndef))
-                                                        card.write(('%s' % nuisance['samples'][sampleName]).ljust(columndef))
-                                                    else :
-                                                        card.write(('-').ljust(columndef))
-                                            else :            
-                                                for sampleName in self.alternative_signals:
-                                                    if alternativeSignalName == sampleName :
-                                                        if sampleName in nuisance['samples'].keys() :
-                                                            card.write(('%s' % nuisance['samples'][sampleName]).ljust(columndef))
-                                                        else :
-                                                            card.write(('-').ljust(columndef))
-                                                for sampleName in cumulative_signals:
-                                                    if sampleName in nuisance['samples'].keys() :
-                                                        card.write(('%s' % nuisance['samples'][sampleName]).ljust(columndef))
-                                                    else :
-                                                        card.write(('-').ljust(columndef))
-                                            for sampleName in self.backgrounds:
-                                                if sampleName in nuisance['samples'].keys() :
-                                                    #card.write(('%-.4f' % nuisance['samples'][sampleName]).ljust(columndef))
-                                                    card.write(('%s' % nuisance['samples'][sampleName]).ljust(columndef))
-                                                else :
-                                                    card.write(('-').ljust(columndef))
-                             
-                                    elif nuisance ['type'] == 'shape' :
-                                        #
-                                        # 'skipCMS' is a flag not to introduce "CMS" automatically in the name
-                                        #      of the nuisance.
-                                        #      It may be needed for combination purposes with ATLAS
-                                        #      and agreed upon for all CMS analyses.
-                                        #      For example: theoretical uncertainties on ggH with migration scheme 2017
-                                        #
-                                        if ('skipCMS' in nuisance.keys()) and nuisance['skipCMS'] == 1 :
-                                            card.write(("" + (nuisance['name'])).ljust(80-20))
-                                        else :
-                                            card.write(("CMS_" + (nuisance['name'])).ljust(80-20))
-                                        if 'AsLnN' in nuisance.keys() and  float(nuisance ['AsLnN']) >= 1:
-                                            print ">>>>>", nuisance['name'], " was derived as a shape uncertainty but is being treated as a lnN"
-                                            card.write(('lnN').ljust(20))
-                                            if alternativeSignalName == "":
-                                                allSelectedSamples = cumulative_signals + self.backgrounds  
-                                            else :
-                                                allSelectedSamples = cumulative_signals + self.backgrounds + alternativeSignalName
-                                            for sampleName in allSelectedSamples:
-                                                if ('all' in nuisance.keys() and nuisance ['all'] == 1) or \
-                                                        sampleName in nuisance['samples'].keys() :  
-                                                    histo     = self._getHisto(cutName+"/"+variableName+'/', 
-                                                                               'histo_' + sampleName)
-                                                    histoUp   = self._getHisto(cutName+"/"+variableName+'/', 
-                                                                               'histo_' + sampleName + '_' + (nuisance['name']) + "Up") 
-                                                    histoDown = self._getHisto(cutName+"/"+variableName+'/',
-                                                                               'histo_' + sampleName + '_' + (nuisance['name']) + "Down")
+              processes = signals + cut_backgrounds
+             
+              print "    Alternative signal: " + str(signalName)
+              alternativeSignalName  = str(signalName)
+              alternativeSignalTitle = ""
+              if alternativeSignalName != "":
+                alternativeSignalTitle = "_" + str(signalName)
 
-                                                    histoIntegral = histo.Integral()
-                                                    histoUpIntegral = histoUp.Integral()
-                                                    histoDownIntegral = histoDown.Integral()
-                                                    if histoIntegral > 0:
-                                                        diffUp = (histoUpIntegral - histoIntegral)/histoIntegral/float(nuisance ['AsLnN'])
-                                                        diffDo = (histoDownIntegral - histoIntegral)/histoIntegral/float(nuisance ['AsLnN'])
-                                                    else: 
-                                                        diffUp = 0.
-                                                        diffDo = 0.
+              # start creating the datacard 
+              cardPath = outputDirDatacard + "/" + cutName + "/" + variableName  + "/datacard" + alternativeSignalTitle + ".txt"
+              print '    Writing to ' + cardPath 
+              card = open( cardPath ,"w")
+
+              print '      headers..'
+              card.write('## Shape input card\n')
+        
+              card.write('imax 1 number of channels\n')
+              card.write('jmax * number of background\n')
+              card.write('kmax * number of nuisance parameters\n') 
+              
+              card.write('-'*100+'\n')
+              card.write('bin         %s' % tagNameToAppearInDatacard+'\n')
+              if len(data) == 0:
+                self._logger.warning( 'no data, no fun! ')
+                #raise RuntimeError('No Data found!')
+                yieldsData['data'] = 0
+
+              card.write('observation %.0f\n' % yieldsData['data'])
             
-                                                    lnNUp = 1. + diffUp
-                                                    lnNDo = 1. + diffDo
-                              
-                                                    card.write((('%-.4f' % lnNUp)+"/"+('%-.4f' % lnNDo)).ljust(columndef))
-                                                else:
-                                                    card.write(('-').ljust(columndef)) 
-                                                    
-                                        else:  
-                                            card.write((nuisance ['type']).ljust(20))
-                                            if 'all' in nuisance.keys() and nuisance ['all'] == 1 : # for all samples
-                                                if alternativeSignalName == "":
-                                                    card.write(''.join([('1.000').ljust(columndef) for name in cumulative_signals  ]))
-                                                else :
-                                                    for name in self.alternative_signals:
-                                                        if name == alternativeSignalName:
-                                                            card.write(''.join([('1.000').ljust(columndef) ]))
-                                                    card.write(''.join([('1.000').ljust(columndef) for name in cumulative_signals  ]))
-                                                card.write(''.join([('1.000').ljust(columndef) for name in self.backgrounds  ]))
-                                                card.write('\n')
-                                            else :
-                                                # apply only to selected samples
-                                                if alternativeSignalName == "":
-                                                    for sampleName in cumulative_signals:
-                                                        if sampleName in nuisance['samples'].keys() :
-                                                            card.write(('1.000').ljust(columndef))                          
-                                                            # save the nuisance histograms in the root file
-                                                            if ('skipCMS' in nuisance.keys()) and nuisance['skipCMS'] == 1 :
-                                                                self._saveHisto(cutName+"/"+variableName+'/',
-                                                                                'histo_' + sampleName + '_' + (nuisance['name']) + "Up",
-                                                                                'histo_' + sampleName + '_' + (nuisance['name']) + "Up"
-                                                                                )
-                                                                self._saveHisto(cutName+"/"+variableName+'/',
-                                                                                'histo_' + sampleName + '_' + (nuisance['name']) + "Down",
-                                                                                'histo_' + sampleName + '_' + (nuisance['name']) + "Down"
-                                                                                )
-                                                            else :
-                                                                self._saveHisto(cutName+"/"+variableName+'/',
-                                                                                'histo_' + sampleName + '_' + (nuisance['name']) + "Up",
-                                                                                'histo_' + sampleName + '_CMS_' + (nuisance['name']) + "Up"
-                                                                                )
-                                                                self._saveHisto(cutName+"/"+variableName+'/',
-                                                                                'histo_' + sampleName + '_' + (nuisance['name']) + "Down",
-                                                                                'histo_' + sampleName + '_CMS_' + (nuisance['name']) + "Down"
-                                                                                )
-                                                                
-                                                        else :
-                                                            card.write(('-').ljust(columndef))
-                                                else :
-                                                    for sampleName in self.alternative_signals:
-                                                        if sampleName == alternativeSignalName :
-                                                            if sampleName in nuisance['samples'].keys() :
-                                                                card.write(('1.000').ljust(columndef))                          
-                                                                # save the nuisance histograms in the root file
-                                                                if ('skipCMS' in nuisance.keys()) and nuisance['skipCMS'] == 1 :
-                                                                    self._saveHisto(cutName+"/"+variableName+'/',
-                                                                                    'histo_' + sampleName + '_' + (nuisance['name']) + "Up",
-                                                                                    'histo_' + sampleName + '_' + (nuisance['name']) + "Up"
-                                                                                    )
-                                                                    self._saveHisto(cutName+"/"+variableName+'/',
-                                                                                    'histo_' + sampleName + '_' + (nuisance['name']) + "Down",
-                                                                                    'histo_' + sampleName + '_' + (nuisance['name']) + "Down"
-                                                                                    )
-                                                                else :
-                                                                    self._saveHisto(cutName+"/"+variableName+'/',
-                                                                                    'histo_' + sampleName + '_' + (nuisance['name']) + "Up",
-                                                                                    'histo_' + sampleName + '_CMS_' + (nuisance['name']) + "Up"
-                                                                                    )
-                                                                    self._saveHisto(cutName+"/"+variableName+'/',
-                                                                                    'histo_' + sampleName + '_' + (nuisance['name']) + "Down",
-                                                                                    'histo_' + sampleName + '_CMS_' + (nuisance['name']) + "Down"
-                                                                                    )
-                                                                
-                                                            else :
-                                                                card.write(('-').ljust(columndef))
-                                                    for sampleName in cumulative_signals:
-                                                        if sampleName in nuisance['samples'].keys() :
-                                                            card.write(('1.000').ljust(columndef))                          
-                                                            # save the nuisance histograms in the root file
-                                                            if ('skipCMS' in nuisance.keys()) and nuisance['skipCMS'] == 1 :
-                                                                self._saveHisto(cutName+"/"+variableName+'/',
-                                                                                'histo_' + sampleName + '_' + (nuisance['name']) + "Up",
-                                                                                'histo_' + sampleName + '_' + (nuisance['name']) + "Up"
-                                                                                )
-                                                                self._saveHisto(cutName+"/"+variableName+'/',
-                                                                                'histo_' + sampleName + '_' + (nuisance['name']) + "Down",
-                                                                                'histo_' + sampleName + '_' + (nuisance['name']) + "Down"
-                                                                                )
-                                                            else :
-                                                                self._saveHisto(cutName+"/"+variableName+'/',
-                                                                                'histo_' + sampleName + '_' + (nuisance['name']) + "Up",
-                                                                                'histo_' + sampleName + '_CMS_' + (nuisance['name']) + "Up"
-                                                                                )
-                                                                self._saveHisto(cutName+"/"+variableName+'/',
-                                                                                'histo_' + sampleName + '_' + (nuisance['name']) + "Down",
-                                                                                'histo_' + sampleName + '_CMS_' + (nuisance['name']) + "Down"
-                                                                                )
-                                                                
-                                                        else :
-                                                            card.write(('-').ljust(columndef))
-                                                for sampleName in self.backgrounds:
-                                                    if sampleName in nuisance['samples'].keys() :
-                                                        card.write(('1.000').ljust(columndef))
-                                                        # save the nuisance histograms in the root file
-                                                        if ('skipCMS' in nuisance.keys()) and nuisance['skipCMS'] == 1 :
-                                                            self._saveHisto(cutName+"/"+variableName+'/',
-                                                                            'histo_' + sampleName + '_' + (nuisance['name']) + "Up",
-                                                                            'histo_' + sampleName + '_' + (nuisance['name']) + "Up"
-                                                                            )
-                                                            self._saveHisto(cutName+"/"+variableName+'/',
-                                                                            'histo_' + sampleName + '_' + (nuisance['name']) + "Down",
-                                                                            'histo_' + sampleName + '_' + (nuisance['name']) + "Down"
-                                                                            )
-                                                        else :
-                                                            self._saveHisto(cutName+"/"+variableName+'/',
-                                                                            'histo_' + sampleName + '_' + (nuisance['name']) + "Up",
-                                                                            'histo_' + sampleName + '_CMS_' + (nuisance['name']) + "Up"
-                                                                            )
-                                                            self._saveHisto(cutName+"/"+variableName+'/',
-                                                                            'histo_' + sampleName + '_' + (nuisance['name']) + "Down",
-                                                                            'histo_' + sampleName + '_CMS_' + (nuisance['name']) + "Down"
-                                                                            )
+              card.write('shapes  *           * '+
+                         'shapes/histos_' + tagNameToAppearInDatacard + ".root" +
+                         '     histo_$PROCESS histo_$PROCESS_$SYSTEMATIC' + '\n')
+            
+              card.write('shapes  data_obs           * '+
+                         'shapes/histos_' + tagNameToAppearInDatacard + ".root" +
+                         '     histo_Data' + '\n')
+            
+              #   shapes  *           * shapes/hww-19.36fb.mH125.of_vh2j_shape_mll.root     histo_$PROCESS histo_$PROCESS_$SYSTEMATIC
+              #   shapes  data_obs    * shapes/hww-19.36fb.mH125.of_vh2j_shape_mll.root     histo_Data
 
+              totalNumberSamples = len(signals)
+              columndef = 30
 
-                                                    else :
-                                                        card.write(('-').ljust(columndef))
+              # adapt column length to long bin names            
+              if len(tagNameToAppearInDatacard) >= (columndef - 5) :
+                columndef = len(tagNameToAppearInDatacard) + 7
+            
+              #print " columndef = ", columndef
+              #print " len(tagNameToAppearInDatacard)  = ", len(tagNameToAppearInDatacard) 
+              #print " tagNameToAppearInDatacard  = ", tagNameToAppearInDatacard
+
+              print '      processes and rates..'
+            
+              card.write('bin'.ljust(80))
+              card.write(''.join([tagNameToAppearInDatacard.ljust(columndef)] * totalNumberSamples)+'\n')
+            
+              card.write('process'.ljust(80))
+              card.write(''.join(name.ljust(columndef) for name in signals))
+              card.write(''.join(name.ljust(columndef) for name in cut_backgrounds))
+              card.write('\n')
+
+              card.write('process'.ljust(80))
+              card.write(''.join(('%d' % signal_ids[name]).ljust(columndef) for name in signals))
+              card.write(''.join(('%d' % background_ids[name]).ljust(columndef) for name in cut_backgrounds))
+              card.write('\n')
+
+              card.write('rate'.ljust(80))
+              card.write(''.join(('%-.4f' % yieldsSig[name]).ljust(columndef) for name in signals))
+              card.write(''.join(('%-.4f' % yieldsBkg[name]).ljust(columndef) for name in cut_backgrounds))
+              card.write('\n')
+
+              card.write('-'*100+'\n')
+
+              print '      nuisances..'
+
+              # add normalization and shape nuisances
+              for nuisanceName, nuisance in nuisances.iteritems():
+                if 'type' not in nuisance:
+                  raise RuntimeError('Nuisance ' + nuisanceName + ' is missing the type specification')
+
+                if nuisanceName == 'stat' or nuisance['type'] == 'rateParam':
+                  # will deal with these later
+                  continue
+
+                # check if a nuisance can be skipped because not in this particular cut
+                if 'cuts' in nuisance and cutName not in nuisance['cuts']:
+                  continue
+
+                if nuisance['type'] in ['lnN', 'lnU']:
+                  card.write((nuisance['name']).ljust(80-20))
+                  card.write((nuisance['type']).ljust(20))
+                  if 'all' in nuisance and nuisance ['all'] == 1: # for all samples
+                    card.write(''.join(('%-.4f' % nuisance['value']).ljust(columndef) for _ in processes))
+                  else:
+                    # apply only to selected samples
+                    for sampleName in processes:
+                      if sampleName in nuisance['samples']:
+                        # in this case nuisance['samples'] is a dict mapping sample name to nuisance values in string
+                        card.write(('%s' % nuisance['samples'][sampleName]).ljust(columndef))
+                      else:
+                        card.write(('-').ljust(columndef))
+                
+                elif nuisance['type'] == 'shape':
+                  #
+                  # 'skipCMS' is a flag not to introduce "CMS" automatically in the name
+                  #      of the nuisance.
+                  #      It may be needed for combination purposes with ATLAS
+                  #      and agreed upon for all CMS analyses.
+                  #      For example: theoretical uncertainties on ggH with migration scheme 2017
+                  #
+                  if 'skipCMS' in nuisance and nuisance['skipCMS'] == 1:
+                    card.write(nuisance['name'].ljust(80-20))
+                  else:
+                    card.write(("CMS_" + nuisance['name']).ljust(80-20))
+
+                  if 'AsLnN' in nuisance and float(nuisance['AsLnN']) >= 1.:
+                    print ">>>>>", nuisance['name'], " was derived as a shape uncertainty but is being treated as a lnN"
+                    card.write(('lnN').ljust(20))
+                    for sampleName in processes:
+                      if ('all' in nuisance and nuisance['all'] == 1) or sampleName in nuisance['samples']:
+                        histo = self._getHisto(cutName, variableName, sampleName)
+                        histoUp = self._getHisto(cutName, variableName, sampleName, '_' + nuisance['name'] + 'Up') 
+                        histoDown = self._getHisto(cutName, variableName, sampleName, '_' + nuisance['name'] + 'Down')
+
+                        if self._skipMissingNuisance and (not histoUp or not histoDown):
+                          print 'Histogram for nuisance', nuisance['name'], 'on sample', sampleName, 'missing'
+                          card.write(('-').ljust(columndef)) 
+                          continue
+
+                        histoIntegral = histo.Integral()
+                        histoUpIntegral = histoUp.Integral()
+                        histoDownIntegral = histoDown.Integral()
+                        if histoIntegral > 0:
+                          diffUp = (histoUpIntegral - histoIntegral)/histoIntegral/float(nuisance['AsLnN'])
+                          diffDo = (histoDownIntegral - histoIntegral)/histoIntegral/float(nuisance['AsLnN'])
+                        else: 
+                          diffUp = 0.
+                          diffDo = 0.
+        
+                        lnNUp = 1. + diffUp
+                        lnNDo = 1. + diffDo
+            
+                        card.write((('%-.4f' % lnNUp)+"/"+('%-.4f' % lnNDo)).ljust(columndef))
+                      else:
+                        card.write(('-').ljust(columndef)) 
+
+                  else:  
+                    card.write('shape'.ljust(20))
+                    for sampleName in processes:
+                      if ('all' in nuisance and nuisance ['all'] == 1) or ('samples' in nuisance and sampleName in nuisance['samples']):
+                        # save the nuisance histograms in the root file
+                        if ('skipCMS' in nuisance.keys()) and nuisance['skipCMS'] == 1:
+                          suffixOut = None
+                        else:
+                          suffixOut = 'CMS_' + nuisance['name']
+
+                        saved = self._saveNuisanceHistos(cutName, variableName, sampleName, '_' + nuisance['name'], suffixOut)
+                        if saved:
+                          card.write('1.000'.ljust(columndef))
+                        else:
+                          # saved can be false if skipMissingNuisance is true and histogram cannot be found
+                          card.write(('-').ljust(columndef))
+                      else:
+                        card.write(('-').ljust(columndef))
+
+                card.write('\n')
+
+              # done with normalization and shape nuisances.
+              # now add the stat nuisances
+              if 'stat' in nuisances:
+                nuisance = nuisances['stat']
+
+                if nuisance['type'] == 'auto':
+                  # use autoMCStats feature of combine
+                  card.write('* autoMCStats ' + nuisance['maxPoiss'] + '  ' + nuisance['includeSignal'])
+                  #  nuisance ['maxPoiss'] =  Number of threshold events for Poisson modelling
+                  #  nuisance ['includeSignal'] =  Include MC stat nuisances on signal processes (1=True, 0=False)
+                  card.write('\n')
+
+                else:
+                  # otherwise we process stat nuisances sample-by-sample
+                  for sampleName in processes:
+                    if sampleName not in nuisance['samples']:
+                      continue
+  
+                    sampleNuisance = nuisance['samples'][sampleName]
+                    sampleIndex = processes.index(sampleName)
+  
+                    if sampleNuisance['typeStat'] == 'uni' : # unified approach
+                      # save the nuisance histograms in the root file
+                      saved = self._saveNuisanceHistos(cutName, variableName, sampleName, 'stat', '_CMS_' + tagNameToAppearInDatacard + "_" + sampleName + "_stat")
+  
+                      if saved:
+                        card.write(('CMS_' + tagNameToAppearInDatacard + "_" + sampleName + "_stat").ljust(80-20))
+                        card.write((nuisance['type']).ljust(20))
+    
+                        # write the line in datacard. Only the column for this sample gets 1.000
+                        for idx in range(len(processes)):
+                          if idx == sampleIndex:
+                            card.write(('1.000').ljust(columndef))
+                          else:
+                            card.write(('-').ljust(columndef))
+    
+                        card.write('\n')
+  
+                    elif sampleNuisance['typeStat'] == 'bbb': # bin-by-bin
+                      histoTemplate = self._getHisto(cutName, variableName, sampleName)
+                      for iBin in range(1, histoTemplate.GetNbinsX()+1):
+                        if 'correlate' in sampleNuisance:
+                          #specify the sample that is source of the variation
+                          tag = "_ibin"+sampleName+"_"
+                          correlate = list(sampleNuisance["correlate"]) # list of sample names to correlate bin-by-bin with this sample
+                        else:
+                          tag = "_ibin_"
+                          correlate = []
+  
+                        # save the nuisance histograms in the root file
+                        saved = self._saveNuisanceHistos(cutName, variableName, sampleName, tag + str(iBin) + '_stat',
+                            '_CMS_' + tagNameToAppearInDatacard + "_" + sampleName + '_ibin_' + str(iBin) + '_stat')
+  
+                        if not saved:
+                          continue
+  
+                        for other in list(correlate):
+                          saved = self._saveNuisanceHistos(cutName, variableName, other, tag + str(iBin) + '_stat',
+                              '_CMS_' + tagNameToAppearInDatacard + "_" + sampleName + '_ibin_' + str(iBin) + '_stat')
+                          if not saved:
+                            correlate.remove(other)
+  
+                        card.write(('CMS_' + tagNameToAppearInDatacard + "_" + sampleName + "_ibin_" + str(iBin) + "_stat").ljust(100-20))
+                        card.write((nuisance['type']).ljust(20))
+  
+                        # write line in datacard. One line per sample per bin
+                        for idx in range(len(processes)):
+                          if idx == sampleIndex or processes[idx] in correlate:
+                            card.write(('1.000').ljust(columndef))
+                          else:
+                            card.write(('-').ljust(columndef))
                       
-                                # new line at the end of any nuisance that is *not* stat ... because in that case it's already done on its own
-                                card.write('\n')
-                 
-                  
-                            # stat nuisances  
-                            if nuisanceName == 'stat' : # 'stat' has a separate treatment, it's the MC/data statistics
-                
-                                if alternativeSignalName != "":
-                                    for sampleName in self.alternative_signals:
-                                        if sampleName == alternativeSignalName :
-                                            if sampleName in nuisance['samples'].keys() :
-                                                if nuisance['samples'][sampleName]['typeStat'] == 'uni' : # unified approach
-                                                    card.write(( 'CMS_' + tagNameToAppearInDatacard + "_" + sampleName + "_stat" ).ljust(80-20))
-                                                    card.write((nuisance ['type']).ljust(20))
+                        card.write('\n')
 
-                                                    # write line in datacard
-                                                    for sampleNameIterator2 in self.alternative_signals:
-                                                        if sampleNameIterator2 == sampleName:
-                                                            card.write(('1.000').ljust(columndef))
-                                                            for sampleNameIterator2 in cumulative_signals:
-                                                                card.write(('-').ljust(columndef))
-                
-                                                    for sampleNameIterator2 in self.backgrounds:
-                                                        card.write(('-').ljust(columndef))
-                
-                                                    card.write('\n')
-                
-                                                    # save the nuisance histograms in the root file
-                                                    self._saveHisto(cutName+"/"+variableName+'/',
-                                                                    'histo_' + sampleName + '_stat' + "Up",
-                                                                    'histo_' + sampleName + '_CMS_' + tagNameToAppearInDatacard + "_" + sampleName + "_stat" + "Up"
-                                                                    )
-                                                    self._saveHisto(cutName+"/"+variableName+'/',
-                                                                    'histo_' + sampleName + '_stat' + "Down",
-                                                                    'histo_' + sampleName + '_CMS_' + tagNameToAppearInDatacard + "_" + sampleName + "_stat" + "Down"
-                                                                    )
-                                                
-                                                if nuisance['samples'][sampleName]['typeStat'] == 'bbb' : # bin-by-bin
-                                                    
-                                                    #print "      sampleName = ", sampleName 
-                                                    histoTemplate = self._fileIn.Get(cutName+'/'+variableName+'/histo_' + sampleName)
-                                                    #print "      type = ", type( histoTemplate )
-                                                
-                                                    for iBin in range(1, histoTemplate.GetNbinsX()+1):
-                       
-                
-                                                        tag = "_ibin_"
-                                                        correlate = []
-                                                        if 'correlate' in nuisance['samples'][sampleName].keys():
-                                                            #specify the sample that is source of the variation
-                                                            tag = "_ibin"+sampleName+"_"
-                                                            correlate = nuisance['samples'][sampleName]["correlate"]
-                           
-                                                            card.write(( 'CMS_' + tagNameToAppearInDatacard + "_" + sampleName + "_ibin_" + str(iBin) + "_stat" ).ljust(100-20))
-                                                            card.write((nuisance ['type']).ljust(20))
+              # now add the "rateParam" for the normalization
+              #  e.g.:            z_norm rateParam  htsearch zll 1 
+              # see: https://twiki.cern.ch/twiki/bin/view/CMS/HiggsWG/SWGuideNonStandardCombineUses#Rate_Parameters
+              # 'rateParam' has a separate treatment -> it's just a line at the end of the datacard. It defines "free floating" samples
+              # I do it here and not before because I want the freee floating parameters at the end of the datacard
+              for nuisance in nuisances.itervalues():
+                if nuisance['type'] != 'rateParam':
+                  continue
 
+                card.write(nuisance['name'].ljust(80-20))
+                card.write('rateParam'.ljust(20))
+                card.write(tagNameToAppearInDatacard.ljust(columndef))   # the bin
+                # there can be only 1 sample per rateParam
+                if len(nuisance['samples']) != 1:
+                  raise RuntimeError('Invalid rateParam: number of samples != 1')
 
-                                                            # write line in datacard
-                                                            for sampleNameIterator2 in self.alternative_signals:
-                                                                if sampleNameIterator2 == sampleName or sampleNameIterator2 in correlate:
-                                                                    card.write(('1.000').ljust(columndef))
-                                                                else :
-                                                                    card.write(('-').ljust(columndef))
+                for sampleName, initialValue in nuisance['samples'].iteritems():
+                  card.write(sampleName.ljust(20))
+                  card.write(('%-.4f' % float(initialValue)).ljust(columndef))
 
-                                                            for sampleNameIterator2 in cumulative_signals:
-                                                                if sampleNameIterator2 == sampleName or sampleNameIterator2 in correlate:
-                                                                    card.write(('1.000').ljust(columndef))
-                                                                else :
-                                                                    card.write(('-').ljust(columndef))
-                     
-                                                            for sampleNameIterator2 in self.backgrounds:
-                                                                if sampleNameIterator2 == sampleName or sampleNameIterator2 in correlate:
-                                                                    card.write(('1.000').ljust(columndef))
-                                                                else:  
-                                                                    card.write(('-').ljust(columndef))
-                                                        
-                                                            card.write('\n')
-                
-                                                            # save the nuisance histograms in the root file
-                                                            self._saveHisto(cutName+"/"+variableName+'/',
-                                                                            'histo_' + sampleName + tag + str(iBin) + '_statUp',
-                                                                            'histo_' + sampleName + '_CMS_' + tagNameToAppearInDatacard + "_" + sampleName + '_ibin_' + str(iBin) + '_stat' + "Up"
-                                                                            )
-                                                            self._saveHisto(cutName+"/"+variableName+'/',
-                                                                            'histo_' + sampleName + tag + str(iBin) + '_statDown',
-                                                                            'histo_' + sampleName + '_CMS_' + tagNameToAppearInDatacard + "_" + sampleName + '_ibin_' + str(iBin) + '_stat' + "Down"
-                                                                            )
-                                                            if correlate != []:
-                                                                for other in correlate: 
-                                                                    self._saveHisto(cutName+"/"+variableName+'/',
-                                                                                    'histo_' + other + tag + str(iBin) + '_statUp',
-                                                                                    'histo_' + other + '_CMS_' + tagNameToAppearInDatacard + "_" + sampleName + '_ibin_' + str(iBin) + '_stat' + "Up"
-                                                                                    )
-                                                                    self._saveHisto(cutName+"/"+variableName+'/',
-                                                                                    'histo_' + other + tag + str(iBin) + '_statDown',
-                                                                                    'histo_' + other + '_CMS_' + tagNameToAppearInDatacard + "_" + sampleName + '_ibin_' + str(iBin) + '_stat' + "Down"
-                                                                                    )
- 
+                card.write('\n')
 
-                                for sampleName in cumulative_signals:
-                                    if sampleName in nuisance['samples'].keys() :
-                                        if nuisance['samples'][sampleName]['typeStat'] == 'uni' : # unified approach
-                       
-                                            card.write(( 'CMS_' + tagNameToAppearInDatacard + "_" + sampleName + "_stat" ).ljust(80-20))
-                                            card.write((nuisance ['type']).ljust(20))
-
-                                            # write line in datacard
-                                            for sampleNameIterator2 in cumulative_signals:
-                                                if sampleNameIterator2 == sampleName:
-                                                    card.write(('1.000').ljust(columndef))
-                                                else :
-                                                    card.write(('-').ljust(columndef))
-                                                    
-                                            for sampleNameIterator2 in self.backgrounds:
-                                                card.write(('-').ljust(columndef))
-                                                    
-                                                card.write('\n')
-                                                    
-                                            # save the nuisance histograms in the root file
-                                            self._saveHisto(cutName+"/"+variableName+'/',
-                                                            'histo_' + sampleName + '_stat' + "Up",
-                                                            'histo_' + sampleName + '_CMS_' + tagNameToAppearInDatacard + "_" + sampleName + "_stat" + "Up"
-                                                            )
-                                            self._saveHisto(cutName+"/"+variableName+'/',
-                                                            'histo_' + sampleName + '_stat' + "Down",
-                                                            'histo_' + sampleName + '_CMS_' + tagNameToAppearInDatacard + "_" + sampleName + "_stat" + "Down"
-                                                            )
-                
-                                        if nuisance['samples'][sampleName]['typeStat'] == 'bbb' : # bin-by-bin
-                                                
-                                            #print "      sampleName = ", sampleName 
-                                            histoTemplate = self._fileIn.Get(cutName+'/'+variableName+'/histo_' + sampleName)
-                                            #print "      type = ", type( histoTemplate )
-                
-                                            for iBin in range(1, histoTemplate.GetNbinsX()+1):
-                       
-                
-                                                tag = "_ibin_"
-                                                correlate = []
-                                                if 'correlate' in nuisance['samples'][sampleName].keys():
-                                                    #specify the sample that is source of the variation
-                                                    tag = "_ibin"+sampleName+"_"
-                                                    correlate = nuisance['samples'][sampleName]["correlate"]
-                           
-                                                card.write(( 'CMS_' + tagNameToAppearInDatacard + "_" + sampleName + "_ibin_" + str(iBin) + "_stat" ).ljust(100-20))
-                                                card.write((nuisance ['type']).ljust(20))
-
-
-                                                # write line in datacard
-                                                for sampleNameIterator2 in self.alternative_signals:
-                                                    if sampleNameIterator2 == alternativeSignalName :
-                                                        if sampleNameIterator2 == sampleName or sampleNameIterator2 in correlate:
-                                                            card.write(('1.000').ljust(columndef))
-                                                        else :
-                                                            card.write(('-').ljust(columndef))
-                                                            
-                                                for sampleNameIterator2 in cumulative_signals:
-                                                    if sampleNameIterator2 == sampleName or sampleNameIterator2 in correlate:
-                                                        card.write(('1.000').ljust(columndef))
-                                                    else :
-                                                        card.write(('-').ljust(columndef))
-                
-                                                for sampleNameIterator2 in self.backgrounds:
-                                                    if sampleNameIterator2 == sampleName or sampleNameIterator2 in correlate:
-                                                        card.write(('1.000').ljust(columndef))
-                                                    else:  
-                                                        card.write(('-').ljust(columndef))
-                                                        
-                                                card.write('\n')
-                
-                                                # save the nuisance histograms in the root file
-                                                self._saveHisto(cutName+"/"+variableName+'/',
-                                                                'histo_' + sampleName + tag + str(iBin) + '_statUp',
-                                                                'histo_' + sampleName + '_CMS_' + tagNameToAppearInDatacard + "_" + sampleName + '_ibin_' + str(iBin) + '_stat' + "Up"
-                                                                )
-                                                self._saveHisto(cutName+"/"+variableName+'/',
-                                                                'histo_' + sampleName + tag + str(iBin) + '_statDown',
-                                                                'histo_' + sampleName + '_CMS_' + tagNameToAppearInDatacard + "_" + sampleName + '_ibin_' + str(iBin) + '_stat' + "Down"
-                                                                )
-                                                if correlate != []:
-                                                    for other in correlate: 
-                                                        self._saveHisto(cutName+"/"+variableName+'/',
-                                                                        'histo_' + other + tag + str(iBin) + '_statUp',
-                                                                        'histo_' + other + '_CMS_' + tagNameToAppearInDatacard + "_" + sampleName + '_ibin_' + str(iBin) + '_stat' + "Up"
-                                                                        )
-                                                        self._saveHisto(cutName+"/"+variableName+'/',
-                                                                        'histo_' + other + tag + str(iBin) + '_statDown',
-                                                                        'histo_' + other + '_CMS_' + tagNameToAppearInDatacard + "_" + sampleName + '_ibin_' + str(iBin) + '_stat' + "Down"
-                                                                        )
- 
-
-                                for sampleName in self.backgrounds:
-                                    if sampleName in nuisance['samples'].keys() :
-                                        if nuisance['samples'][sampleName]['typeStat'] == 'uni' : # unified approach
-                       
-                                            card.write(( 'CMS_' + tagNameToAppearInDatacard + "_" + sampleName + "_stat" ).ljust(80-20))
-                                            card.write((nuisance ['type']).ljust(20))
-                
-                                            # write line in datacard
-                                            for sampleNameIterator2 in self.signals:
-                                                card.write(('-').ljust(columndef))
-                
-                                            for sampleNameIterator2 in self.backgrounds:
-                                                if sampleNameIterator2 == sampleName :
-                                                    card.write(('1.000').ljust(columndef))
-                                                else :
-                                                    card.write(('-').ljust(columndef))
-                                                    
-                                            card.write('\n')
-                
-                                            # save the nuisance histograms in the root file
-                                            self._saveHisto(cutName+"/"+variableName+'/',
-                                                            'histo_' + sampleName + '_stat' + "Up",
-                                                            'histo_' + sampleName + '_CMS_' + tagNameToAppearInDatacard + "_" + sampleName + "_stat" + "Up"
-                                                            )
-                                            self._saveHisto(cutName+"/"+variableName+'/',
-                                                            'histo_' + sampleName + '_stat' + "Down",
-                                                            'histo_' + sampleName + '_CMS_' + tagNameToAppearInDatacard + "_" + sampleName + "_stat" + "Down"
-                                                            )
-                
-                                        if nuisance['samples'][sampleName]['typeStat'] == 'bbb' : # bin-by-bin
-                
-                                            histoTemplate = self._fileIn.Get(cutName+'/'+variableName+'/histo_' + sampleName)
-                                            #print "type = ", type( histoTemplate )
-                
-                
-                                            for iBin in range(1, histoTemplate.GetNbinsX()+1):
-
-        
-                                                tag = "_ibin_"
-                                                correlate = []
-                                                if 'correlate' in nuisance['samples'][sampleName].keys():
-                                                    #specify the sample that is source of the variation
-                                                    tag = "_ibin"+sampleName+"_"
-                                                    print tag
-                                                    correlate = nuisance['samples'][sampleName]["correlate"]
-   
-                       
-                                                card.write(( 'CMS_' + tagNameToAppearInDatacard + "_" + sampleName + "_ibin_" + str(iBin) + "_stat" ).ljust(80-20))
-                                                card.write((nuisance ['type']).ljust(20))
-                
-                                                # write line in datacard
-                                                for sampleNameIterator2 in self.alternative_signals:
-                                                    if sampleNameIterator2 == alternativeSignalName :
-                                                        if sampleNameIterator2 == sampleName or sampleNameIterator2 in correlate:
-                                                            card.write(('1.000').ljust(columndef))
-                                                        else :
-                                                            card.write(('-').ljust(columndef))
-
-                                                for sampleNameIterator2 in cumulative_signals:
-                                                    if sampleNameIterator2 == sampleName or sampleNameIterator2 in correlate:
-                                                        card.write(('1.000').ljust(columndef))
-                                                    else:   
-                                                        card.write(('-').ljust(columndef))
-                
-                                                for sampleNameIterator2 in self.backgrounds:
-                                                    if sampleNameIterator2 == sampleName or sampleNameIterator2 in correlate:
-                                                        card.write(('1.000').ljust(columndef))
-                                                    else :
-                                                        card.write(('-').ljust(columndef))
-                
-                                                card.write('\n')
-                
-                                                # save the nuisance histograms in the root file
-                                                self._saveHisto(cutName+"/"+variableName+'/',
-                                                                'histo_' + sampleName + tag + str(iBin) + '_statUp',
-                                                                'histo_' + sampleName + '_CMS_' + tagNameToAppearInDatacard + "_" + sampleName + '_ibin_' + str(iBin) + '_stat' + "Up"
-                                                                )
-                                                self._saveHisto(cutName+"/"+variableName+'/',
-                                                                'histo_' + sampleName + tag + str(iBin) + '_statDown',
-                                                                'histo_' + sampleName + '_CMS_' + tagNameToAppearInDatacard + "_" + sampleName + '_ibin_' + str(iBin) + '_stat' + "Down"
-                                                                )
-                                                if correlate != []:
-                                                    for other in correlate:
-                                                        self._saveHisto(cutName+"/"+variableName+'/',
-                                                                        'histo_' + other + tag + str(iBin) + '_statUp',
-                                                                        'histo_' + other + '_CMS_' + tagNameToAppearInDatacard + "_" + sampleName + '_ibin_' + str(iBin) + '_stat' + "Up"
-                                                                        )
-                                                        self._saveHisto(cutName+"/"+variableName+'/',
-                                                                        'histo_' + other + tag + str(iBin) + '_statDown',
-                                                                        'histo_' + other + '_CMS_' + tagNameToAppearInDatacard + "_" + sampleName + '_ibin_' + str(iBin) + '_stat' + "Down"
-                                                                        ) 
-                
-
-#                            if nuisanceName == 'stat' : # 'stat' has a separate treatment, it's the MC/data statistics
-                                if 'type' in nuisance.keys() :
-                                    if nuisance['type'] == 'auto' :
-                                        card.write('* autoMCStats ' + nuisance ['maxPoiss'] + '  ' + nuisance ['includeSignal'] )
-                                        #  nuisance ['maxPoiss'] =  Number of threshold events for Poisson modelling
-                                        #  nuisance ['includeSignal'] =  Include MC stat nuisances on signal processes (1=True, 0=False)
-                                        card.write('\n')
-               
-               
-               
-                            # now add the "rateParam" for the normalization
-                            #  e.g.:            z_norm rateParam  htsearch zll 1 
-                            # see: https://twiki.cern.ch/twiki/bin/view/CMS/HiggsWG/SWGuideNonStandardCombineUses#Rate_Parameters
-                            if nuisanceName != 'stat' : # 'stat' has a separate treatment, it's the MC/data statistics
-                                if 'type' in nuisance.keys() : # some nuisances may not have "type" ... why?
-                                    #print "nuisance[type] = ", nuisance ['type']
-                                    # 'rateParam' has a separate treatment -> it's just a line at the end of the datacard. It defines "free floating" samples
-                                    # I do it here and not before because I want the freee floating parameters at the end of the datacard
-                                    if nuisance ['type'] == 'rateParam' :
-                                        card.write((nuisance['name']).ljust(80-20))
-                                        card.write((nuisance ['type']).ljust(20))
-                                        card.write((tagNameToAppearInDatacard).ljust(columndef))   # the bin
-                                        # apply only to selected samples
-                                        for sampleName in self.signals:
-                                            if sampleName in nuisance['samples'].keys() :
-                                                card.write((sampleName).ljust(20))
-                                                card.write(('%-.4f' % float(nuisance['samples'][sampleName])).ljust(columndef))
-                                        for sampleName in self.backgrounds:
-                                            if sampleName in nuisance['samples'].keys() :
-                                                card.write((sampleName).ljust(20))
-                                                card.write(('%-.4f' % float(nuisance['samples'][sampleName])).ljust(columndef))
-                                        card.write('\n')
-
-
-                    # now add other nuisances            
-                    # Are there other kind of nuisances I forgot?
+              # now add other nuisances            
+              # Are there other kind of nuisances I forgot?
             
-                    card.write('-'*100+'\n')
+              card.write('-'*100+'\n')
 
-                    card.write('\n')
-                    card.close()
+              card.write('\n')
+              card.close()
 
+              print '      done.'
 
+            self._outFile.Close()
 
+        if type(self._fileIn) is dict:
+          for source in self._fileIn.values():
+            source.Close()
+        else:
+          self._fileIn.Close()
 
-
-
-   
     # _____________________________________________________________________________
-    def _saveHisto(self, folderName, histoName, histoNameOut):     
-       shapeName = folderName + histoName
-       histo = self._fileIn.Get(shapeName)
-       print " shapeName = ", shapeName
-       print " --> ", histoNameOut
-       print " --> histo = ", histo
-       histo.SetName(histoNameOut)
-       self._outFile.cd()
-       histo.Write()
-       
+    def _saveNuisanceHistos(self, cutName, variableName, sampleName, suffixIn, suffixOut = None):
+        histoUp = self._getHisto(cutName, variableName, sampleName, suffixIn + 'Up')
+        histoDown = self._getHisto(cutName, variableName, sampleName, suffixIn + 'Down')
 
-    def _getHisto(self, folderName, histoName):
-      shapeName = folderName + histoName
-      histo = self._fileIn.Get(shapeName)
-      return histo
+        if self._skipMissingNuisance and (not histoUp or not histoDown):
+          print 'Up/down histogram for', cutName, variableName, sampleName, suffixIn, 'missing'
+          return False
+      
+        histoUp.SetDirectory(self._outFile)
+        histoDown.SetDirectory(self._outFile)
+        if suffixOut:
+            histoUp.SetName('histo_%s%sUp' % (sampleName, suffixOut))
+            histoDown.SetName('histo_%s%sDown' % (sampleName, suffixOut))
 
+        self._outFile.cd()
+        if not self._outFile.Get(histoUp.GetName()):
+            histoUp.Write()
+        if not self._outFile.Get(histoDown.GetName()):
+            histoDown.Write()
 
+        return True
 
+    # _____________________________________________________________________________
+    def _getHisto(self, cutName, variableName, sampleName, suffix = None):
+        shapeName = '%s/%s/histo_%s' % (cutName, variableName, sampleName)
+        if suffix:
+            shapeName += suffix
 
-
-
-
-
-
+        if type(self._fileIn) is dict:
+            # by-sample ROOT file
+            histo = self._fileIn[sampleName].Get(shapeName)
+        else:
+            # Merged single ROOT file
+            histo = self._fileIn.Get(shapeName)
+      
+        return histo
 
 
 if __name__ == '__main__':
@@ -911,8 +512,8 @@ if __name__ == '__main__':
     parser.add_option('--inputFile'          , dest='inputFile'         , help='input directory'                            , default='./input.root')
     parser.add_option('--structureFile'      , dest='structureFile'     , help='file with datacard configurations'          , default=None )
     parser.add_option('--nuisancesFile'      , dest='nuisancesFile'     , help='file with nuisances configurations'         , default=None )
-    parser.add_option('--cardList'            , dest="cardList"           , help="List of cuts to produce datacards"          , default=[], type='string' , action='callback' , callback=list_maker('cardList',','))
-
+    parser.add_option('--cardList'           , dest="cardList"          , help="List of cuts to produce datacards"          , default=[], type='string' , action='callback' , callback=list_maker('cardList',','))
+    parser.add_option('--skipMissingNuisance', dest='skipMissingNuisance', help="Don't write nuisance lines when histograms are missing", default=False, action='store_true')
           
     # read default parsing options as well
     hwwtools.addOptions(parser)
@@ -928,7 +529,6 @@ if __name__ == '__main__':
     print " inputFile =                  ", opt.inputFile
     print " outputDirDatacard =          ", opt.outputDirDatacard
  
- 
     if not opt.debug:
         pass
     elif opt.debug == 2:
@@ -938,11 +538,11 @@ if __name__ == '__main__':
         print 'Logging level set to INFO (%d)' % opt.debug
         logging.basicConfig( level=logging.INFO )
 
+    ROOT.TH1.SetDefaultSumw2(True)
       
     factory = DatacardFactory()
-    factory._energy    = opt.energy
-    factory._lumi      = opt.lumi
     factory._tag       = opt.tag
+    factory._skipMissingNuisance = opt.skipMissingNuisance
     
     # ~~~~
     samples = {}
@@ -1003,6 +603,3 @@ if __name__ == '__main__':
     
     
     factory.makeDatacards( opt.inputFile ,opt.outputDirDatacard, variables, cuts, samples, structure, nuisances)
-    
-        
-        

--- a/ShapeAnalysis/scripts/mkPlot.py
+++ b/ShapeAnalysis/scripts/mkPlot.py
@@ -19,8 +19,6 @@ from collections import OrderedDict
 #
 
 from LatinoAnalysis.ShapeAnalysis.PlotFactory import PlotFactory   
-   
-
 
 if __name__ == '__main__':
     sys.argv = argv
@@ -137,18 +135,17 @@ if __name__ == '__main__':
       exec(handle)
       handle.close()
    
-    variables = {}
-    if os.path.exists(opt.variablesFile) :
-      handle = open(opt.variablesFile,'r')
-      exec(handle)
-      handle.close()
-    
     cuts = {}
     if os.path.exists(opt.cutsFile) :
       handle = open(opt.cutsFile,'r')
       exec(handle)
       handle.close()
-   
+
+    variables = {}
+    if os.path.exists(opt.variablesFile) :
+      handle = open(opt.variablesFile,'r')
+      exec(handle)
+      handle.close()
    
     # check if only one cut or only one variable
     # is requested, and filter th elist of cuts and variables

--- a/ShapeAnalysis/scripts/mkPlot.py
+++ b/ShapeAnalysis/scripts/mkPlot.py
@@ -44,6 +44,7 @@ if __name__ == '__main__':
     parser.add_option('--maxLinearScale' , dest='maxLinearScale' , help='scale factor for max Y in linear plots (1.45 magic number as default)'     , default=1.45   ,    type=float   )
     parser.add_option('--outputDirPlots' , dest='outputDirPlots' , help='output directory'                           , default='./')
     parser.add_option('--inputFile'      , dest='inputFile'      , help='input file with histograms'                 , default='input.root')
+    parser.add_option('--tag'            , dest='tag'            , help='Tag used for the shape file name. Used if inputFile is a directory', default=None)
     parser.add_option('--nuisancesFile'  , dest='nuisancesFile'  , help='file with nuisances configurations'         , default=None )
 
     parser.add_option('--onlyVariable'   , dest='onlyVariable'   , help='draw only one variable (may be needed in post-fit plots)'          , default=None)
@@ -104,6 +105,7 @@ if __name__ == '__main__':
 
       
     factory = PlotFactory()
+    factory._tag       = opt.tag
     factory._energy    = opt.energy
     factory._lumi      = opt.lumi
     factory._plotNormalizedDistributions = opt.plotNormalizedDistributions

--- a/Tools/python/batchTools.py
+++ b/Tools/python/batchTools.py
@@ -63,7 +63,10 @@ class batchJobs :
          if not 'Target' in batchSplit and len(targetList)>1 :
            kTarget = 'AllTargets'
          elif type(iTarget) is tuple:
-           kTarget = '%s%d' % iTarget
+           if len(iTarget) == 2:
+              kTarget = '%s%d' % iTarget
+           else:
+              kTarget = '%s%d.%d' % iTarget
          else:
            kTarget = iTarget
    

--- a/Tools/scripts/haddfast
+++ b/Tools/scripts/haddfast
@@ -1,0 +1,242 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import glob
+import tempfile
+import time
+import multiprocessing
+import tempfile
+import logging
+import shutil
+_argv = sys.argv
+sys.argv = sys.argv[:1]
+import ROOT
+
+logging.basicConfig(level = logging.INFO)
+LOG = logging.getLogger(__name__)
+
+tdirectoryfile = ROOT.TDirectoryFile.Class()
+
+def merge(indir, outdir, pname = ''):
+    """
+    Write histograms in indir (TDirectoryFile) into outdir (TDirectoryFile). Add if target already exists.
+    Histograms are written to disk at each call and not kept in memory. There will be multiple versions
+    of the same histogram in the output file (and therefore wasted disk space) if Add is invoked. Use the
+    compress option to purge unused versions at the end.
+    """
+
+    nnew = 0
+    nadd = 0
+
+    LOG.debug(pname + '/' + indir.GetName())
+
+    # Collect all existing keys in outdir into a dict to avoid calling outdir.Get() (slow)
+    # Pick up only the latest versions (highest key cycle number)
+    outkeys = {}
+    for key in outdir.GetListOfKeys():
+        name = key.GetName()
+        try:
+            if outkeys[name].GetCycle() > key.GetCycle():
+                continue
+        except KeyError:
+            pass
+
+        outkeys[name] = key
+
+    # Convert the dict of keys into a dict of histograms
+    outcont = dict((name, key.ReadObj()) for name, key in outkeys.iteritems())
+
+    # Repeat for the input keys
+    inkeys = {}
+    for key in indir.GetListOfKeys():
+        name = key.GetName()
+        try:
+            if inkeys[name].GetCycle() > key.GetCycle():
+                continue
+        except KeyError:
+            pass
+
+        inkeys[name] = key
+
+    # Read input objects and write to output
+    for name, key in inkeys.iteritems():
+        obj = key.ReadObj()
+
+        if obj.IsA() is tdirectoryfile:
+            # If the input object is a directory, recurse
+
+            try:
+                outsubdir = outcont[name]
+            except KeyError:
+                outsubdir = outdir.mkdir(name)
+
+            nsubnew, nsubadd = merge(obj, outsubdir, pname + '/' + indir.GetName())
+            nnew += nsubnew
+            nadd += nsubadd
+
+        else:
+            # Write to outdir or add to an existing histogram
+
+            outdir.cd()
+            try:
+                outhist = outcont[name]
+            except KeyError:
+                obj.SetDirectory(outdir)
+                obj.Write()
+                nnew += 1
+            else:
+                outhist.Add(obj)
+                outhist.Write(name)
+                outhist.Delete()
+                nadd += 1
+
+        # Delete the object from memory immediately
+        # Using TObject::Delete because TDirectory::Delete does different things
+        ROOT.TObject.Delete(obj)
+
+    return nnew, nadd
+
+def writeto(sourcePaths, targetPath):
+    """
+    Write contents of sourcePaths (list of path strings) into targetPath (string).
+    Target is closed after processing each source to clean memory.
+    """
+
+    LOG.info('merge %s -> %s', sourcePaths, targetPath)
+
+    target = ROOT.TFile.Open(targetPath, 'recreate')
+    # This is critical (and safe) - see https://root-forum.cern.ch/t/tfile-close-slow/24179
+    ROOT.gROOT.GetListOfFiles().Remove(target)
+
+    _nadd = 0
+
+    for path in sourcePaths:
+        start = time.time()
+        source = ROOT.TFile.Open(path)
+        ROOT.gROOT.GetListOfFiles().Remove(source)
+
+        nnew, nadd = merge(source, target)
+
+        source.Close()
+
+        target.cd()
+        target.Write()
+        target.Close()
+
+        LOG.info('%s -> %s: %d new, %d merged (%.1f s)', path, targetPath, nnew, nadd, time.time() - start)
+
+        _nadd += nadd
+        if path != sourcePaths[-1]:
+            if _nadd > 1000000:
+                # purge duplicate keys by compressing
+                os.rename(targetPath, targetPath + '.tmp')
+                writeto([targetPath + '.tmp'], targetPath)
+                os.unlink(targetPath + '.tmp')
+                _nadd = 0
+    
+            target = ROOT.TFile.Open(targetPath, 'update')
+            ROOT.gROOT.GetListOfFiles().Remove(target)
+
+if __name__ == '__main__':
+    sys.argv = _argv
+
+    from argparse import ArgumentParser
+    
+    argParser = ArgumentParser(description = 'Faster hadd for histogram-only files.')
+    argParser.add_argument('target', metavar = 'PATH', help = 'Target file.')
+    argParser.add_argument('source', metavar = 'PATH', nargs = '+', help = 'Source files.')
+    argParser.add_argument('--write-direct', '-D', action = 'store_true', dest = 'writeDirect', help = 'Write directly to the target path.')
+    argParser.add_argument('--force-write', '-f', action = 'store_true', dest = 'forceWrite', help = 'Overwrite existing output file.')
+    argParser.add_argument('--compress', '-C', action = 'store_true', dest = 'compress', help = 'Remake the output file to purge multi-key entries.')
+    argParser.add_argument('--num-procs', '-j', metavar = 'N', dest = 'numProcs', type = int, default = 1, help = 'Number of subprocesses to invoke.')
+    
+    args = argParser.parse_args()
+   
+    if not args.forceWrite and os.path.exists(args.target):
+        sys.stderr.write('Target file exists.')
+        sys.exit(1)
+    
+    sourcePaths = []
+    for path in args.source:
+        if '*' in path:
+            sourcePaths.extend(glob.glob(path))
+        else:
+            sourcePaths.append(path)
+
+    if args.writeDirect and not args.compress:
+        targetName = args.target
+    else:
+        dtemp = tempfile.mkdtemp()
+        targetName = '%s/target.root' % dtemp
+
+    if args.numProcs == 1:
+        writeto(sourcePaths, targetName)
+    else:
+        allSources = [(path, False) for path in sourcePaths]
+        sources = {}
+        processes = []
+
+        def wait_until_lessthan(n):
+            while True:
+                for proc, targetPath in list(processes):
+                    if proc.is_alive():
+                        continue
+
+                    proc.join()
+                    if proc.exitcode != 0:
+                        raise RuntimeError('Merge failed.')
+
+                    processes.remove((proc, targetPath))
+                    allSources.append((targetPath, True))
+
+                    for path, istmp in sources.pop(proc.name):
+                        if istmp:
+                            shutil.rmtree(os.path.dirname(path))
+
+                if len(processes) < n:
+                    break
+
+                time.sleep(1)
+
+        ijob = 0
+
+        while len(allSources) > 1 or len(processes) != 0:
+            wait_until_lessthan(args.numProcs)
+
+            if len(allSources) > 1:
+                jobid = 'proc%d' % ijob
+    
+                sources[jobid] = [allSources.pop(), allSources.pop()]
+                sourcePaths = [s[0] for s in sources[jobid]]
+                dtemp = tempfile.mkdtemp()
+                targetPath = dtemp + '/tmp.root'
+                proc = multiprocessing.Process(target = writeto, args = (sourcePaths, targetPath), name = jobid)
+                proc.daemon = True
+                proc.start()
+                processes.append((proc, targetPath))
+
+                ijob += 1
+
+        wait_until_lessthan(1)
+
+        if allSources[0][1]:
+            if args.compress or (not args.writeDirect):
+                targetName = allSources[0][0]
+            else:
+                shutil.move(allSources[0][0], targetName)
+                shutil.rmtree(os.path.dirname(allSources[0][0]))
+        else:
+            shutil.copyfile(allSources[0][0], targetName)
+    
+    if args.compress:
+        LOG.info('Compressing')
+        writeto([targetName], args.target)
+        shutil.rmtree(os.path.dirname(targetName))
+
+    elif not args.writeDirect:
+        if os.path.exists(args.target):
+            os.unlink(args.target)
+
+        shutil.move(targetName, args.target)
+        shutil.rmtree(os.path.dirname(targetName))


### PR DESCRIPTION
For differential analysis we end up with millions of histograms, and the existing factories weren't scaling. The updates here are transparent and won't change the outcome of standard usage, but adds a few new features:
 - mkDatacards and mkPlots can use an input directory as an --inputFile argument. The directory must contain one histogram ROOT file per sample. This eliminates the need to run hadd over the sample-split shape files (which is a pure copy operation because no histogram is merged across samples)
 - Samples can be split by number of events within a file. With AsMuchAsPossible as the splitting option, for samples with FilesPerJob = 1 and EventsPerJob != 0, multiple jobs are created for each file, processing parts of the file. This may not be useful in the end though; I added the feature because processing time increased dramatically by adding many cuts corresponding to ptH and njet binning, but then later found a way to speed that up (see next bullet).
 - 'categories' and 'subsamples' are introduced to the ShapeFactory syntax. Categories can be set in a cut, and represents non-overlapping subdivision of the cut. MultiDraw version >= 2.0.5 is needed to use this feature. Using categories is much faster than having many cuts. I will present syntax examples in a Latinos meeting. Subsamples are essentially just a renaming of the 'bins' feature (to be set in samples.py), but with an output that makes more sense.
 - mkShapesMulti --doHadd=1 will use an "haddfast" script. It's a faster version of hadd that is limited to files with histograms only. The script still takes tens of minutes to merge files with millions of histograms though.