### PR TITLE
Update 2017 QCD xsec and correct type QCD_10to30 -> QCD_15to30

### DIFF
--- a/NanoGardener/python/framework/samples/fall17_nAOD_v1.py
+++ b/NanoGardener/python/framework/samples/fall17_nAOD_v1.py
@@ -291,7 +291,7 @@ Samples['QCD_Pt-30to50_EMEnriched']        = {'nanoAOD' :'/QCD_Pt-30to50_EMEnric
 Samples['QCD_Pt-50to80_EMEnriched']        = {'nanoAOD' :'/QCD_Pt-50to80_EMEnriched_TuneCP5_13TeV_pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM'} 
 Samples['QCD_Pt-30toInf_DoubleEMEnriched'] = {'nanoAOD' :'/QCD_Pt-30toInf_DoubleEMEnriched_MGG-40to80_TuneCP5_13TeV_Pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM'}
 
-Samples['QCD_Pt_10to30']            = {'nanoAOD' : '/QCD_Pt_15to30_TuneCP5_13TeV_pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM'}
+Samples['QCD_Pt_15to30']            = {'nanoAOD' : '/QCD_Pt_15to30_TuneCP5_13TeV_pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM'}
 Samples['QCD_Pt_30to50']            = {'nanoAOD' : '/QCD_Pt_30to50_TuneCP5_13TeV_pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM'}
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/NanoGardener/python/framework/samples/samplesCrossSections2017.py
+++ b/NanoGardener/python/framework/samples/samplesCrossSections2017.py
@@ -581,6 +581,10 @@ samples['QCD_HT700to1000']                      .extend( ['xsec=6363'   ,       
 samples['QCD_HT1000to1500']                     .extend( ['xsec=1048'   ,       'kfact=1.000',  'ref=I'] )
 samples['QCD_HT1500to2000']                     .extend( ['xsec=102.3'  ,       'kfact=1.000',  'ref=I'] )
 samples['QCD_HT2000toInf']                      .extend( ['xsec=20.23'  ,       'kfact=1.000',  'ref=I'] )
+
+Samples['QCD_Pt_15to30']                        .extend( ['xsec=1245000000'  ,       'kfact=1.000',  'ref=I'] )
+Samples['QCD_Pt_30to50']                        .extend( ['xsec=106900000'   ,       'kfact=1.000',  'ref=I'] )
+
 # GJets
 samples['GJetsDR04_HT40To100'] .extend( ['xsec=17420', 'kfact=1.000', 'ref=I'] )
 samples['GJetsDR04_HT100To200'] .extend( ['xsec=5382', 'kfact=1.000', 'ref=I'] )


### PR DESCRIPTION
@xjanssen . Could you review this PR?

I correct the name of QCD_10to30 sample and add xsec of each QCD samples you requested