### PR TITLE
Import libraries to properly compile MELA macros

### DIFF
--- a/NanoGardener/scripts/mkPostProc.py
+++ b/NanoGardener/scripts/mkPostProc.py
@@ -101,8 +101,10 @@ if __name__ == '__main__':
 # ---------------------------------------- Compile all root macros before sending jobs
 
     if options.runBatch :
-      ROOT.gSystem.Load("libZZMatrixElementMELA.so")
-      ROOT.gSystem.Load("libMelaAnalyticsCandidateLOCaster.so")
+      pathLib = CMSSW + '/lib/'+os.listdir(CMSSW + '/lib/')[0]+'/'
+      for fn in ["libZZMatrixElementMELA.so", "libMelaAnalyticsCandidateLOCaster.so"]: # Needed to compile MELA macros
+        if os.path.isfile(pathLib+fn):
+          ROOT.gSystem.Load(fn)
       pathRootMacro = CMSSW + '/src/LatinoAnalysis/Gardener/python/variables/'
       for fn in os.listdir(pathRootMacro):
         if os.path.isfile(pathRootMacro+fn) and ( fn.endswith('.C') or fn.endswith('.cc') ):

--- a/NanoGardener/scripts/mkPostProc.py
+++ b/NanoGardener/scripts/mkPostProc.py
@@ -101,6 +101,8 @@ if __name__ == '__main__':
 # ---------------------------------------- Compile all root macros before sending jobs
 
     if options.runBatch :
+      ROOT.gSystem.Load("libZZMatrixElementMELA.so")
+      ROOT.gSystem.Load("libMelaAnalyticsCandidateLOCaster.so")
       pathRootMacro = CMSSW + '/src/LatinoAnalysis/Gardener/python/variables/'
       for fn in os.listdir(pathRootMacro):
         if os.path.isfile(pathRootMacro+fn) and ( fn.endswith('.C') or fn.endswith('.cc') ):


### PR DESCRIPTION
I found that certain libraries need to be imported here for macros based on MELA to be compiled properly (like https://github.com/latinos/LatinoAnalysis/blob/master/Gardener/python/variables/melaReweighterWW.C).

After this PR we'll be able to use newer versions of the MELA packages (https://github.com/latinos/setup/blob/13TeV/SetupShapeOnly.sh#L117-L120).