### PR TITLE
Add genonly config

### DIFF
--- a/NanoGardener/python/data/MCGenOnly_outputbranches.txt
+++ b/NanoGardener/python/data/MCGenOnly_outputbranches.txt
@@ -1,0 +1,15 @@
+drop *
+keep run
+keep luminosityBlock
+keep event
+keep genWeight
+keep nGenPart
+keep GenPart_*
+keep LHE_*
+keep nLHEPart
+keep LHEPart_*
+keep GenMET_*
+keep Pileup_*
+keep nGenDressedLepton
+keep GenDressedLepton_*
+keep HTXS_*

--- a/NanoGardener/python/framework/PostProcMaker.py
+++ b/NanoGardener/python/framework/PostProcMaker.py
@@ -298,7 +298,8 @@ class PostProcMaker():
      
      if not iStep == 'UEPS' : 
 
-       self._targetDir = self._Sites[self._LocalSite]['treeBaseDir']+'/'+iProd+'/'
+       self._targetDir = '/eos/cms/store/user/yiiyama/HWWNano/'+iProd+'/'
+       #self._targetDir = self._Sites[self._LocalSite]['treeBaseDir']+'/'+iProd+'/'
        if not self._iniStep == 'Prod' : self._targetDir += self._iniStep+'__'+iStep+'/'
        else                           : self._targetDir += iStep+'/'
 
@@ -560,9 +561,13 @@ class PostProcMaker():
      else: 
        fPy.write('                    cut=None ,       \n')
      if 'branchsel' in self._Steps[iStep] :
-       fPy.write('                    branchsel='+self._Steps[iStep]['branchsel']+' ,       \n')
+       fPy.write('                    branchsel="'+self._Steps[iStep]['branchsel']+'",       \n')
      else:
        fPy.write('                    branchsel=None , \n')
+     if 'outputbranchsel' in self._Steps[iStep]:
+       fPy.write('                    outputbranchsel="'+self._Steps[iStep]['outputbranchsel']+'",       \n')
+     else:
+       fPy.write('                    outputbranchsel=None , \n')
      fPy.write('                    modules=[        \n')
      if self._Steps[iStep]['isChain'] :
        for iSubStep in  self._Steps[iStep]['subTargets'] :

--- a/NanoGardener/python/framework/PostProcMaker.py
+++ b/NanoGardener/python/framework/PostProcMaker.py
@@ -298,8 +298,7 @@ class PostProcMaker():
      
      if not iStep == 'UEPS' : 
 
-       self._targetDir = '/eos/cms/store/user/yiiyama/HWWNano/'+iProd+'/'
-       #self._targetDir = self._Sites[self._LocalSite]['treeBaseDir']+'/'+iProd+'/'
+       self._targetDir = self._Sites[self._LocalSite]['treeBaseDir']+'/'+iProd+'/'
        if not self._iniStep == 'Prod' : self._targetDir += self._iniStep+'__'+iStep+'/'
        else                           : self._targetDir += iStep+'/'
 

--- a/NanoGardener/python/framework/Steps_cfg.py
+++ b/NanoGardener/python/framework/Steps_cfg.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import os
+
 ## --------------------------------- Some predefined sequence Chains -----------------------------------------
 
 LNuQQSamples=[ 'GluGluHToWWToLNuQQ_M1000', 'GluGluHToWWToLNuQQ_M115', 'GluGluHToWWToLNuQQ_M120', 'GluGluHToWWToLNuQQ_M124', 'GluGluHToWWToLNuQQ_M125', 'GluGluHToWWToLNuQQ_M126', 'GluGluHToWWToLNuQQ_M130', 'GluGluHToWWToLNuQQ_M135', 'GluGluHToWWToLNuQQ_M140', 'GluGluHToWWToLNuQQ_M145', 'GluGluHToWWToLNuQQ_M150', 'GluGluHToWWToLNuQQ_M1500', 'GluGluHToWWToLNuQQ_M155', 'GluGluHToWWToLNuQQ_M160', 'GluGluHToWWToLNuQQ_M165', 'GluGluHToWWToLNuQQ_M170', 'GluGluHToWWToLNuQQ_M175', 'GluGluHToWWToLNuQQ_M180', 'GluGluHToWWToLNuQQ_M190', 'GluGluHToWWToLNuQQ_M200', 'GluGluHToWWToLNuQQ_M2000', 'GluGluHToWWToLNuQQ_M210', 'GluGluHToWWToLNuQQ_M230', 'GluGluHToWWToLNuQQ_M250', 'GluGluHToWWToLNuQQ_M2500', 'GluGluHToWWToLNuQQ_M270', 'GluGluHToWWToLNuQQ_M300', 'GluGluHToWWToLNuQQ_M3000', 'GluGluHToWWToLNuQQ_M350', 'GluGluHToWWToLNuQQ_M400', 'GluGluHToWWToLNuQQ_M4000', 'GluGluHToWWToLNuQQ_M450', 'GluGluHToWWToLNuQQ_M500', 'GluGluHToWWToLNuQQ_M5000', 'GluGluHToWWToLNuQQ_M550', 'GluGluHToWWToLNuQQ_M600', 'GluGluHToWWToLNuQQ_M650', 'GluGluHToWWToLNuQQ_M700', 'GluGluHToWWToLNuQQ_M750', 'GluGluHToWWToLNuQQ_M750_NWA', 'GluGluHToWWToLNuQQ_M800', 'GluGluHToWWToLNuQQ_M900', 'VBFHToWWToLNuQQ_M1000', 'VBFHToWWToLNuQQ_M115', 'VBFHToWWToLNuQQ_M120', 'VBFHToWWToLNuQQ_M124', 'VBFHToWWToLNuQQ_M125', 'VBFHToWWToLNuQQ_M126', 'VBFHToWWToLNuQQ_M130', 'VBFHToWWToLNuQQ_M135', 'VBFHToWWToLNuQQ_M140', 'VBFHToWWToLNuQQ_M145', 'VBFHToWWToLNuQQ_M150', 'VBFHToWWToLNuQQ_M1500', 'VBFHToWWToLNuQQ_M155', 'VBFHToWWToLNuQQ_M160', 'VBFHToWWToLNuQQ_M165', 'VBFHToWWToLNuQQ_M170', 'VBFHToWWToLNuQQ_M175', 'VBFHToWWToLNuQQ_M180', 'VBFHToWWToLNuQQ_M190', 'VBFHToWWToLNuQQ_M200', 'VBFHToWWToLNuQQ_M2000', 'VBFHToWWToLNuQQ_M210', 'VBFHToWWToLNuQQ_M230', 'VBFHToWWToLNuQQ_M250', 'VBFHToWWToLNuQQ_M2500', 'VBFHToWWToLNuQQ_M270', 'VBFHToWWToLNuQQ_M300', 'VBFHToWWToLNuQQ_M3000', 'VBFHToWWToLNuQQ_M350', 'VBFHToWWToLNuQQ_M400', 'VBFHToWWToLNuQQ_M4000', 'VBFHToWWToLNuQQ_M450', 'VBFHToWWToLNuQQ_M500', 'VBFHToWWToLNuQQ_M5000', 'VBFHToWWToLNuQQ_M550', 'VBFHToWWToLNuQQ_M600', 'VBFHToWWToLNuQQ_M650', 'VBFHToWWToLNuQQ_M700', 'VBFHToWWToLNuQQ_M750', 'VBFHToWWToLNuQQ_M750_NWA', 'VBFHToWWToLNuQQ_M800', 'VBFHToWWToLNuQQ_M900' ]
@@ -248,6 +250,14 @@ Steps = {
                                      'rochesterMC','trigMC','LeptonSF','puW','l2Kin', 'l3Kin', 'l4Kin','formulasMC','EmbeddingVeto'],
                 },
 
+  'MCGenOnly': {
+                  'isChain'    : True  ,
+                  'do4MC'      : True  ,
+                  'do4Data'    : False ,
+                  'subTargets' : ['PromptParticlesGenVars','GenVar', 'HiggsGenVars', 'ggHTheoryUncertainty', 'DressedLeptons',
+                                  'baseW'],
+                  'outputbranchsel': os.getenv('CMSSW_BASE') + '/src/LatinoAnalysis/NanoGardener/python/data/MCGenOnly_outputbranches.txt'
+               },
 
 ## ------- WgStar MC:
 
@@ -745,6 +755,15 @@ Steps = {
                   'declare'    : 'HMvars = lambda : HighMassVariables()',
                   'module'     : 'HMvars()',
                },
+
+    'assignRun': {
+                  'isChain'    : False ,
+                  'do4MC'      : True  ,
+                  'do4Data'    : True  ,
+                  'import'     : 'LatinoAnalysis.NanoGardener.modules.RunAssigner' ,
+                  'declare'    : 'assignRun = lambda: RunAssigner("RPLME_CMSSW")',
+                  'module'     : 'assignRun()',
+            },
 
 ## ------- MODULES: Object Handling
 

--- a/NanoGardener/python/modules/RunAssigner.py
+++ b/NanoGardener/python/modules/RunAssigner.py
@@ -1,0 +1,52 @@
+import ROOT
+import os
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+
+from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
+from LatinoAnalysis.NanoGardener.data.TrigMaker_cfg import Trigger
+
+class RunAssigner(Module):
+    '''
+    Assign run period to MC events based on run luminosity fractions.
+    ''' 
+
+    def __init__(self, cmssw = 'Full2016', seed=65539):
+        self.TriggerCfg = Trigger[cmssw]
+
+        self.random = ROOT.TRandom3(seed)
+
+    def beginJob(self): 
+        pass
+
+    def endJob(self):
+        pass
+
+    def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        self.initReaders(inputTree) # initReaders must be called in beginFile
+        self.out = wrappedOutputTree
+
+        self.out.branch('run_period', 'I')
+
+    def endFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        pass
+
+    def initReaders(self,tree): # this function gets the pointers to Value and ArrayReaders and sets them in the C++ worker class
+
+        self.RunFrac = []
+        lumi = 0.
+        for RunCfg in self.TriggerCfg.itervalues():
+            lumi += RunCfg['lumi']
+            self.RunFrac.append(lumi)
+
+        for i in range(len(self.RunFrac)):
+            self.RunFrac[i] /= lumi
+       
+    def analyze(self, event):
+        """process event, return True (go to next module) or False (fail, go to next event)"""
+
+        x = self.random.Rndm()
+        run_period = next(i + 1 for i in range(len(self.RunFrac)) if self.RunFrac[i] >= x)
+
+        self.out.fillBranch('run_period', run_period)
+
+        return True


### PR DESCRIPTION
Adding a gen-only standalone step for making very light-weight trees for gen-level studies.

This PR will conflict with #55 in the sense that I fixed (what I think is) a bug in PostProcMaker where branchsel was not quoted, but in #55 Pedro decided to add the quotes in the Steps config. So once both are merged, (I think) we should remove the quotes from the DropBranches step.
By the way the use of `os.getenv('CMSSW_BASE')` in the MCGenOnly step in this PR is one way to achieve portability requested in https://github.com/latinos/LatinoAnalysis/pull/55#issuecomment-525699917

There is another module `RunAssigner` - this is just an extraction of the `run_period` assignment of TrigMaker. I ended up not using it, but it might come in handy later; `run_period` is used by other modules but we don't always want to run TrigMaker.