### PR TITLE
deal with subsamples and categories

### DIFF
--- a/ShapeAnalysis/python/PlotFactory.py
+++ b/ShapeAnalysis/python/PlotFactory.py
@@ -233,32 +233,15 @@ class PlotFactory:
               if 'samples' in variable and sampleName not in variable['samples']:
                 continue
 
-              if 'subsamples' in plotdef:
-                histos[sampleName] = None
-                for subsample in plotdef['subsamples']:
-                  shapeName = cutName+"/"+variableName+'/histo_' + sampleName + '_' + subsample
-                  print '     -> shapeName = ', shapeName
-                  if type(fileIn) is dict:
-                    histo = fileIn[sampleName].Get(shapeName)
-                  else:
-                    histo = fileIn.Get(shapeName)
-                  print ' --> ', histo
-                  print 'new_histo_' + sampleName + '_' + cutName + '_' + variableName
-                  if histos[sampleName] is None:
-                    histos[sampleName] = histo.Clone('new_histo_' + sampleName + '_' + cutName + '_' + variableName)
-                  else:
-                    histos[sampleName].Add(histo)
-                    
+              shapeName = cutName+"/"+variableName+'/histo_' + sampleName
+              print '     -> shapeName = ', shapeName
+              if type(fileIn) is dict:
+                histo = fileIn[sampleName].Get(shapeName)
               else:
-                shapeName = cutName+"/"+variableName+'/histo_' + sampleName
-                print '     -> shapeName = ', shapeName
-                if type(fileIn) is dict:
-                  histo = fileIn[sampleName].Get(shapeName)
-                else:
-                  histo = fileIn.Get(shapeName)
-                print ' --> ', histo
-                print 'new_histo_' + sampleName + '_' + cutName + '_' + variableName
-                histos[sampleName] = histo.Clone('new_histo_' + sampleName + '_' + cutName + '_' + variableName)                      
+                histo = fileIn.Get(shapeName)
+              print ' --> ', histo
+              print 'new_histo_' + sampleName + '_' + cutName + '_' + variableName
+              histos[sampleName] = histo.Clone('new_histo_' + sampleName + '_' + cutName + '_' + variableName)                      
               
               #print "     -> sampleName = ", sampleName, " --> ", histos[sampleName].GetTitle(), " --> ", histos[sampleName].GetName(), " --> ", histos[sampleName].GetNbinsX()
               #for iBinAmassiro in range(1, histos[sampleName].GetNbinsX()+1):
@@ -1193,6 +1176,8 @@ class PlotFactory:
               CMS_lumi.lumi_sqrtS = legend['sqrt']
             if 'lumi' in legend.keys() :
               CMS_lumi.lumi_13TeV = legend['lumi']
+            else:
+              CMS_lumi.lumi_13TeV = 'L = %.1f fb^{-1}' % self._lumi
         
             # Simple example of macro: plot with CMS name and lumi text
             #  (this script does not pretend to work in all configurations)

--- a/ShapeAnalysis/python/utils.py
+++ b/ShapeAnalysis/python/utils.py
@@ -1,0 +1,99 @@
+def flatten_samples(samples):
+    ## flatten the subsamples (create full samples named sample_subsample)
+    subsamplesmap = []
+    for sname in samples.keys():
+        sample = samples[sname]
+        if 'subsamples' not in sample:
+            continue
+        
+        subsamplesmap.append((sname, []))
+        for sub in sample['subsamples']:
+            samples['%s_%s' % (sname, sub)] = sample
+            subsamplesmap[-1][1].append('%s_%s' % (sname, sub))
+
+        sample.pop('subsamples')
+        samples.pop(sname)
+
+    return subsamplesmap
+
+def flatten_cuts(cuts):
+    ## flatten the categories (create full cuts named cut_category)
+    categoriesmap = []
+    for cname in cuts.keys():
+        cut = cuts[cname]
+        if 'categories' not in cut:
+            continue
+        
+        categoriesmap.append((cname, []))
+        for cat in cut['categories']:
+            cuts['%s_%s' % (cname, cat)] = cut
+            categoriesmap[-1][1].append('%s_%s' % (cname, cat))
+
+        cut.pop('categories')
+        cuts.pop(cname)
+
+    return categoriesmap
+
+def update_variables_with_categories(variables, categoriesmap):
+    ## variables can have "cuts" specifications
+    for variable in variables.itervalues():
+        if 'cuts' not in variable:
+            continue
+
+        cutspec = variable['cuts']
+
+        for cname, categories in categoriesmap:
+            if cname not in cutspec:
+                continue
+
+            # original cut is in the spec
+            cutspec.remove(cname)
+
+            # if a category (subcut) is also in the spec, we won't touch this variable
+            if len(set(cutspec) & set(categories)) != 0:
+                continue
+          
+            # otherwise we replace the cut with all the categories
+            cutspec.extend(categories)
+
+def update_nuisances_with_subsamples(nuisances, subsamplesmap):
+    for nuisance in nuisances.itervalues():
+        if 'samples' not in nuisance:
+            continue
+        
+        samplespec = nuisance['samples']
+          
+        for sname, subsamples in subsamplesmap:
+            if sname not in samplespec:
+                continue
+            
+            # original sample is in the spec
+            sconfig = samplespec.pop(sname)
+
+            # if a subsample is also in the spec, we won't toucn this any more
+            if len(set(samplespec.iterkeys()) & set(subsamples)) != 0:
+                continue
+  
+            # otherwise we replace the sample with all the subsamples
+            samplespec.update((subsample, sconfig) for subsample in subsamples)
+
+def update_nuisances_with_categories(nuisances, categoriesmap):
+    for nuisance in nuisances.itervalues():
+        if 'cuts' not in nuisance:
+            continue
+        
+        cutspec = nuisance['cuts']
+
+        for cname, categories in categoriesmap:
+            if cname not in cutspec:
+                continue
+            
+            # original cut is in the spec
+            cutspec.remove(cname)
+
+            # if a category (subcut) is also in the spec, we won't touch this nuisance
+            if len(set(cutspec) & set(categories)) != 0:
+                continue
+  
+            # otherwise we replace the cut with all the categories
+            cutspec.extend(categories)

--- a/ShapeAnalysis/scripts/mkDatacards.py
+++ b/ShapeAnalysis/scripts/mkDatacards.py
@@ -24,9 +24,6 @@ class DatacardFactory:
     # _____________________________________________________________________________
     def __init__(self):
       
-        self._variables = {}
-        self._cuts = {}
-        self._samples = {}
         self._fileIn = None
         self._skipMissingNuisance = False
 
@@ -39,14 +36,10 @@ class DatacardFactory:
         print "==== makeDatacards ===="
         print "======================="
         
-        self._variables = variables
-        self._samples   = samples
-        self._cuts      = cuts
-
         if os.path.isdir(inputFile):
           # ONLY COMPATIBLE WITH OUTPUTS MERGED TO SAMPLE LEVEL!!
           self._fileIn = {}
-          for sampleName in self._samples:
+          for sampleName in samples:
             self._fileIn[sampleName] = ROOT.TFile.Open(inputFile+'/plots_%s_ALL_%s.root' % (self._tag, sampleName))
             if not self._fileIn[sampleName]:
               raise RuntimeError('Input file for sample ' + sampleName + ' missing')
@@ -63,7 +56,7 @@ class DatacardFactory:
         # divide the list of samples among signal, background and data
         isig = 0
         ibkg = 1
-        for sampleName in self._samples:
+        for sampleName in samples:
           if structureFile[sampleName]['isSignal'] != 0:
             signal_ids[sampleName] = isig
             isig -= 1
@@ -86,7 +79,7 @@ class DatacardFactory:
           os.mkdir(outputDirDatacard + "/")
 
         # loop over cuts. One directory per cut will be created
-        for cutName in self._cuts:
+        for cutName in cuts:
           print "cut = ", cutName
           try:
             shutil.rmtree(outputDirDatacard + "/" + cutName)
@@ -111,7 +104,7 @@ class DatacardFactory:
           print "  sampleNames = ", cut_signals + cut_backgrounds
           
           # loop over variables
-          for variableName, variable in self._variables.iteritems():
+          for variableName, variable in variables.iteritems():
             if 'cuts' in variable and cutName not in variable['cuts']:
               continue
               
@@ -124,7 +117,8 @@ class DatacardFactory:
             os.mkdir(outputDirDatacard + "/" + cutName + "/" + variableName + "/shapes/") # and the folder for the root files 
 
             self._outFile = ROOT.TFile.Open(outputDirDatacard + "/" + cutName + "/" + variableName + "/shapes/histos_" + tagNameToAppearInDatacard + ".root", 'recreate')
-                    
+            ROOT.gROOT.GetListOfFiles().Remove(self._outFile)
+
             # prepare yields
             yieldsSig  = {}
             yieldsBkg  = {}
@@ -249,8 +243,7 @@ class DatacardFactory:
 
                 # check if a nuisance can be skipped because not in this particular cut
                 if 'cuts' in nuisance and cutName not in nuisance['cuts']:
-                    if 'sampleCuts' not in nuisance or len(set((proc, cutName) for proc in processes) & set(nuisance['samplesCuts'])) == 0:
-                        continue
+                  continue
 
                 if nuisance['type'] in ['lnN', 'lnU']:
                   card.write((nuisance['name']).ljust(80-20))
@@ -260,8 +253,8 @@ class DatacardFactory:
                     card.write(('shape').ljust(20))
                     for sampleName in processes:
                       if ('all' in nuisance and nuisance['all'] == 1) or \
-                              ('samples' in nuisance and sampleName in nuisance['samples']) or \
-                              ('samplesCuts' in nuisance and (sampleName, cutName) in nuisance['samplesCuts']):
+                              ('samples' in nuisance and sampleName in nuisance['samples']):
+
                         histo = self._getHisto(cutName, variableName, sampleName)
 
                         histoUp = histo.Clone('%s_%sUp' % (histo.GetName(), nuisance['name']))
@@ -293,7 +286,7 @@ class DatacardFactory:
                     else:
                       # apply only to selected samples
                       for sampleName in processes:
-                        if sampleName in nuisance['samples'] or ('samplesCuts' in nuisance and (sampleName, cutName) in nuisance['samplesCuts']):
+                        if sampleName in nuisance['samples']:
                           # in this case nuisance['samples'] is a dict mapping sample name to nuisance values in string
                           card.write(('%s' % nuisance['samples'][sampleName]).ljust(columndef))
                         else:
@@ -317,8 +310,7 @@ class DatacardFactory:
                     card.write(('lnN').ljust(20))
                     for sampleName in processes:
                       if ('all' in nuisance and nuisance['all'] == 1) or \
-                              ('samples' in nuisance and sampleName in nuisance['samples']) or \
-                              ('samplesCuts' in nuisance and (sampleName, cutName) in nuisance['samplesCuts']):
+                              ('samples' in nuisance and sampleName in nuisance['samples']):
                         histo = self._getHisto(cutName, variableName, sampleName)
                         histoUp = self._getHisto(cutName, variableName, sampleName, '_' + nuisance['name'] + 'Up') 
                         histoDown = self._getHisto(cutName, variableName, sampleName, '_' + nuisance['name'] + 'Down')
@@ -383,8 +375,7 @@ class DatacardFactory:
                     card.write('shape'.ljust(20))
                     for sampleName in processes:
                       if ('all' in nuisance and nuisance ['all'] == 1) or \
-                              ('samples' in nuisance and sampleName in nuisance['samples']) or \
-                              ('samplesCuts' in nuisance and (sampleName, cutName) in nuisance['samplesCuts']):
+                              ('samples' in nuisance and sampleName in nuisance['samples']):
                         # save the nuisance histograms in the root file
                         if ('skipCMS' in nuisance.keys()) and nuisance['skipCMS'] == 1:
                           suffixOut = None
@@ -499,7 +490,7 @@ class DatacardFactory:
                   raise RuntimeError('Invalid rateParam: number of samples != 1')
 
                 sampleName, initialValue = nuisance['samples'].items()[0]
-                if sampleName not in self._samples:
+                if sampleName not in samples:
                   raise RuntimeError('Invalid rateParam: unknown sample %s' % sampleName)
 
                 card.write(sampleName.ljust(20))
@@ -619,13 +610,20 @@ if __name__ == '__main__':
     print " outputDirDatacard =          ", opt.outputDirDatacard
  
     if not opt.debug:
-        pass
+      pass
     elif opt.debug == 2:
-        print 'Logging level set to DEBUG (%d)' % opt.debug
-        logging.basicConfig( level=logging.DEBUG )
+      print 'Logging level set to DEBUG (%d)' % opt.debug
+      logging.basicConfig( level=logging.DEBUG )
     elif opt.debug == 1:
-        print 'Logging level set to INFO (%d)' % opt.debug
-        logging.basicConfig( level=logging.INFO )
+      print 'Logging level set to INFO (%d)' % opt.debug
+      logging.basicConfig( level=logging.INFO )
+
+    if opt.nuisancesFile == None :
+      print " Please provide the nuisances structure if you want to add nuisances "
+
+    if opt.structureFile == None :
+      print " Please provide the datacard structure "
+      exit ()
 
     ROOT.TH1.SetDefaultSumw2(True)
       
@@ -633,25 +631,51 @@ if __name__ == '__main__':
     factory._tag       = opt.tag
     factory._skipMissingNuisance = opt.skipMissingNuisance
     
-    # ~~~~
+    ## load the samples
     samples = {}
     if os.path.exists(opt.samplesFile) :
       handle = open(opt.samplesFile,'r')
       exec(handle)
       handle.close()
-   
+
+    ## load the cuts
     cuts = {}
     if os.path.exists(opt.cutsFile) :
       handle = open(opt.cutsFile,'r')
       exec(handle)
       handle.close()
 
+    ## load the variables
     variables = {}
     if os.path.exists(opt.variablesFile) :
       handle = open(opt.variablesFile,'r')
       exec(handle)
       handle.close()
-      
+
+    ## load the nuisances
+    nuisances = collections.OrderedDict()
+    if os.path.exists(opt.nuisancesFile) :
+      handle = open(opt.nuisancesFile,'r')
+      exec(handle)
+      handle.close()
+
+    import LatinoAnalysis.ShapeAnalysis.utils as utils
+
+    subsamplesmap = utils.flatten_samples(samples)
+    categoriesmap = utils.flatten_cuts(cuts)
+
+    utils.update_variables_with_categories(variables, categoriesmap)
+    utils.update_nuisances_with_subsamples(nuisances, subsamplesmap)
+    utils.update_nuisances_with_categories(nuisances, categoriesmap)
+
+    ## load the structure file (use flattened sample and cut names)
+    structure = collections.OrderedDict()
+    if os.path.exists(opt.structureFile) :
+      handle = open(opt.structureFile,'r')
+      exec(handle)
+      handle.close()
+
+    ## command-line cuts restrictions
     if len(opt.cardList)>0:
       try:
         newCuts = []
@@ -666,26 +690,5 @@ if __name__ == '__main__':
       for iCut in cuts:
         if not iCut in opt.cardList : cut2del.append(iCut)
       for iCut in cut2del : del cuts[iCut]   
-  
-    # ~~~~
-    nuisances = collections.OrderedDict()
-    if opt.nuisancesFile == None :
-       print " Please provide the nuisances structure if you want to add nuisances "
-       
-    if os.path.exists(opt.nuisancesFile) :
-      handle = open(opt.nuisancesFile,'r')
-      exec(handle)
-      handle.close()
-
-    # ~~~~
-    structure = collections.OrderedDict()
-    if opt.structureFile == None :
-       print " Please provide the datacard structure "
-       exit ()
-       
-    if os.path.exists(opt.structureFile) :
-      handle = open(opt.structureFile,'r')
-      exec(handle)
-      handle.close()
     
     factory.makeDatacards( opt.inputFile ,opt.outputDirDatacard, variables, cuts, samples, structure, nuisances)

--- a/ShapeAnalysis/scripts/mkPlot.py
+++ b/ShapeAnalysis/scripts/mkPlot.py
@@ -164,6 +164,23 @@ if __name__ == '__main__':
       handle = open(opt.variablesFile,'r')
       exec(handle)
       handle.close()
+
+    nuisances = {}
+    if opt.nuisancesFile == None :
+      print " Please provide the nuisances structure if you want to add nuisances "
+    elif os.path.exists(opt.nuisancesFile) :
+      handle = open(opt.nuisancesFile,'r')
+      exec(handle)
+      handle.close()
+
+    import LatinoAnalysis.ShapeAnalysis.utils as utils
+
+    subsamplesmap = utils.flatten_samples(samples)
+    categoriesmap = utils.flatten_cuts(cuts)
+
+    utils.update_variables_with_categories(variables, categoriesmap)
+    utils.update_nuisances_with_subsamples(nuisances, subsamplesmap)
+    utils.update_nuisances_with_categories(nuisances, categoriesmap)
    
     # check if only one cut or only one variable
     # is requested, and filter th elist of cuts and variables
@@ -178,7 +195,6 @@ if __name__ == '__main__':
         del variables[toRemove]
            
       print  " variables = ", variables
-      
 
     if opt.onlyCut != None :
       list_to_remove = []
@@ -189,15 +205,7 @@ if __name__ == '__main__':
         del cuts[toRemove]
 
       print  " cuts = ", cuts
-
-    nuisances = {}
-    if opt.nuisancesFile == None :
-      print " Please provide the nuisances structure if you want to add nuisances "
-    elif os.path.exists(opt.nuisancesFile) :
-      handle = open(opt.nuisancesFile,'r')
-      exec(handle)
-      handle.close() 
-        
+       
     groupPlot = OrderedDict()
     plot = {}
     legend = {}


### PR DESCRIPTION
`subsamples` and `categories` features make mkShapes more efficient but cause trouble downstream (mkPlot and mkDatacard). Here's a way to automatically deal with them (just flattens out all subsamples into new samples and categories into new cuts). There is a bit of nontrivial choice that has been made:
- If a nuisance specifies just the full sample, the sample entry is replaced with all subsamples
- If a nuisance specifies subsample names, those entries are not touched and unspecified subsamples are not inserted

plot.py and structure.py should be written assuming fully flattened samples / cuts.