### PR TITLE
Added FatJet Mass scale and smear with variations

### DIFF
--- a/NanoGardener/python/data/FatJetMaker_cfg.py
+++ b/NanoGardener/python/data/FatJetMaker_cfg.py
@@ -5,7 +5,7 @@ CleanFatJet_br = {
                      'CleanFatJet_eta',
                      'CleanFatJet_phi',
                      'CleanFatJet_mass',
-                     'CleanFatJet_tau21'
+                     'CleanFatJet_tau21',
                     ],
 
                'I': [
@@ -14,3 +14,26 @@ CleanFatJet_br = {
               }
 
 CleanFatJet_var = ['pt', 'eta', 'phi']
+
+
+# Fatjet JMS (central,uncertainty) for high purity category 
+# Source: https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetWtagging
+fatjet_mass_scale_sf = {
+        2016: (1, 0.0094),           #  tau21 cut not specified
+        2017: (0.982, 0.004),   # tau21 < 45 High Purity region
+        2018: (0.997, 0.004),   # tau21 < 45 High Purity region
+}
+
+# Fatjet JMR (central,uncertainty) scale factors for high purity category
+# Source: https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetWtagging
+fatjet_mass_resolution_MC = {
+        2016: 10.1,       #  tau21 cut not specified
+        2017: 8.753,      # tau21 < 45 High Purity region
+        2018: 8.257,      # tau21 < 45 High Purity region
+}
+fatjet_mass_resolution_sf = {
+        2016: (1, 0.20),        #  tau21 cut not specified
+        2017: (1.09, 0.05),      # tau21 < 45 High Purity region
+        2018: (1.243, 0.041),    # tau21 < 45 High Purity region
+}
+

--- a/NanoGardener/python/framework/Steps_cfg.py
+++ b/NanoGardener/python/framework/Steps_cfg.py
@@ -911,10 +911,17 @@ Steps = {
                   'do4MC'      : True  ,
                   'do4Data'    : True  ,
                   'import'     : 'LatinoAnalysis.NanoGardener.modules.FatJetMaker',
-                   #'declare'    : 'fatjetMaker = lambda : FatJetMaker(minpt=200, maxeta=2.4, max_tau21=0.45, mass_range=[65, 105], over_lepR=0.8, over_jetR=0.8)',
                   'declare'    : 'fatjetMaker = lambda : FatJetMaker(jetid=0, minpt=200, maxeta=2.4, max_tau21=0.45, mass_range=[40, 150], over_lepR=0.8, over_jetR=0.8)',
-                   #'declare'    : 'fatjetMaker = lambda : FatJetMaker(jetid=1 ,minpt=200, maxeta=2.4, max_tau21=999., mass_range=[40, 13000], over_lepR=0.8, over_jetR=1.0)',
                   'module'     : 'fatjetMaker()'
+    },
+
+    'CorrFatJetMass' : {
+                  'isChain'    : False ,
+                  'do4MC'      : True  ,
+                  'do4Data'    : False  ,
+                  'import'     : 'LatinoAnalysis.NanoGardener.modules.FatJetMassScaler',
+                  'declare'    : 'fatjetmass_scaler = lambda : FatJetMassScaler(year=RPLME_YEAR, type="scale_smear", kind="Central",collection="CleanFatJet")',
+                  'module'     : 'fatjetmass_scaler()'
     },
 
    'susyGen': {
@@ -1723,6 +1730,43 @@ Steps = {
                   'subTargets' : ['do_MupTdo','trigMCKeepRun','LeptonSF','l2Kin', 'l3Kin', 'l4Kin','DYMVA','MonoHiggsMVA','formulasEMBED'],
                },
 
+#-------------------------  Fatjet mass scale
+  'FatJetMass_up' : {
+                  'isChain'    : False ,
+                  'do4MC'      : True  ,
+                  'do4Data'    : False  ,
+                  'import'     : 'LatinoAnalysis.NanoGardener.modules.FatJetMassScaler',
+                  'declare'    : 'fj_massup = lambda : FatJetMassScaler(year=RPLME_YEAR, type="scale", kind="Up",collection="CleanFatJet")',
+                  'module'     : 'fj_massup()'
+    },
+
+  'FatJetMass_do' : {
+                  'isChain'    : False ,
+                  'do4MC'      : True  ,
+                  'do4Data'    : False  ,
+                  'import'     : 'LatinoAnalysis.NanoGardener.modules.FatJetMassScaler',
+                  'declare'    : 'fj_massdo = lambda : FatJetMassScaler(year=RPLME_YEAR, type="scale", kind="Down",collection="CleanFatJet")',
+                  'module'     : 'fj_massdo()'
+    },
+
+   'FatJetMassRes_up' : {
+                  'isChain'    : False ,
+                  'do4MC'      : True  ,
+                  'do4Data'    : False  ,
+                  'import'     : 'LatinoAnalysis.NanoGardener.modules.FatJetMassScaler',
+                  'declare'    : 'fj_resup = lambda : FatJetMassScaler(year=RPLME_YEAR, type="smear", kind="Up",collection="CleanFatJet")',
+                  'module'     : 'fj_resup()'
+    },
+
+  'FatJetMassRes_do' : {
+                  'isChain'    : False ,
+                  'do4MC'      : True  ,
+                  'do4Data'    : False  ,
+                  'import'     : 'LatinoAnalysis.NanoGardener.modules.FatJetMassScaler',
+                  'declare'    : 'fj_resdo = lambda : FatJetMassScaler(year=RPLME_YEAR, type="smear", kind="Down",collection="CleanFatJet")',
+                  'module'     : 'fj_resdo()'
+    },
+
 # ------------------------------------ SKIMS : CUTS ONLY ----------------------------------------------------------
 
   'TrgwSel'   : {
@@ -2126,7 +2170,6 @@ Steps = {
       'subTargets': ['fakeWstep1l','CleanFatJet', 'VBSjjlnu_pairing', 'VBSjjlnu_kin'],
       'onlySample' : LNuJJ_VBS_Samples_data2017
   },
-
 
 
 # ------------------------------------ SPECIAL STEPS: HADD & UEPS -------------------------------------------------

--- a/NanoGardener/python/modules/FatJetMaker.py
+++ b/NanoGardener/python/modules/FatJetMaker.py
@@ -37,7 +37,7 @@ class FatJetMaker(Module):
 
 
     '''
-    def __init__(self,jetid=0, minpt=200.0, maxeta=2.4, max_tau21=0.45, mass_range=[65, 105], 
+    def __init__(self, jetid=0, minpt=200.0, maxeta=2.4, max_tau21=0.45, mass_range=[65, 105], 
                     over_lepR =0.8, over_jetR = 0.8):
         self.jetid = jetid
         self.minpt = minpt
@@ -134,6 +134,7 @@ class FatJetMaker(Module):
                        #print("Found lepton matched to FatJet")
 
             if goodFatJet:
+                #  The mass will be scaled and smeared in FatJetMassScaler module
                 # save the CleanFatJet info
                 output_vars["CleanFatJet_pt"].append(fj_pt)
                 output_vars["CleanFatJet_eta"].append(fj_eta)

--- a/NanoGardener/python/modules/FatJetMassScaler.py
+++ b/NanoGardener/python/modules/FatJetMassScaler.py
@@ -1,0 +1,127 @@
+import ROOT
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+import re
+from math import sqrt
+
+from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection 
+from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
+from LatinoAnalysis.NanoGardener.data.FatJetMaker_cfg import CleanFatJet_br, CleanFatJet_var
+from LatinoAnalysis.NanoGardener.data.FatJetMaker_cfg import fatjet_mass_scale_sf as JMS_sf
+from LatinoAnalysis.NanoGardener.data.FatJetMaker_cfg import fatjet_mass_resolution_sf as JMR_sf
+from LatinoAnalysis.NanoGardener.data.FatJetMaker_cfg import fatjet_mass_resolution_MC as JMR_MC
+
+class FatJetMassScaler(Module):
+    '''
+    This module is used to vary both the scale and the resolution on the FatJet mass. 
+    It can be used both for nominal scale/smear and for variations
+    type=scale apply the scale
+    type=smear apply the resoluton
+    type=scale_smear both apply scale and resolution
+    kind=Central/Up/Down
+    '''
+    def __init__(self,year, type,  kind, collection="CleanFatJet"):
+        self.year = year
+        self.collection = collection
+        self.type = type
+        self.kind = kind
+         # initialize random number generator
+        self.rnd = ROOT.TRandom3(12345)
+
+        if self.year not in JMS_sf or self.year not in JMR_sf:
+            print("ERROR! No JMS/JMR sf for year ", year)
+
+    def beginJob(self):
+        pass
+    def endJob(self):
+        pass
+
+    def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        self.out = wrappedOutputTree
+        # Smearing factor saved for variations
+        self.out.branch(self.collection+'_smearfactor', "F", lenVar="n"+self.collection)
+        # Mass
+        self.out.branch(self.collection+"_mass", "F", lenVar="n"+self.collection)
+
+    def endFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        pass
+    
+    def analyze(self, event):
+        fatjets = Collection(event, self.collection)
+        masses = []
+        smearfactors = []
+
+        # if len(fatjets)>0 and self.kind != "Central":  
+        #     print "previous smear:  ", [ f.smearfactor for f in fatjets]
+        #     print "previous mass: ",[f.mass for f in fatjets]
+
+        for fatjet in fatjets:
+            if self.kind == "Central":
+                # Nominal scale/smearing
+                scaled_mass = self.scaleFatJetMass(fatjet.mass, "Central")
+                smeared_mass, smearfactor = self.smearFatJetMass(scaled_mass, 1, "Central")
+                masses.append(scaled_mass)
+                smearfactors.append(smearfactor)
+            else:
+                # Variations
+                if self.type == "scale":
+                    masses.append(self.scaleFatJetMass(fatjet.mass, self.kind))
+                elif self.type == "smear":
+                    new_mass, smearfactor = self.smearFatJetMass(fatjet.mass, fatjet.smearfactor, self.kind)
+                    masses.append(new_mass)
+                    smearfactors.append(smearfactor)
+
+        # save output
+        self.out.fillBranch(self.collection+"_mass", masses)
+
+        if self.kind == "Central" or self.type == "smear":
+            self.out.fillBranch(self.collection+"_smearfactor", smearfactors)
+
+        return True
+
+        
+
+    # Scale and smear fatjet mass nominal
+    def scaleFatJetMass(self, mass, kind):
+        scale_nominal = JMS_sf[self.year][0]
+        if kind == "Central": 
+            new_mass = mass * scale_nominal
+        else:
+            if kind == "Up":
+                scale_var = scale_nominal + JMS_sf[self.year][1]
+            elif kind == "Down":
+                scale_var = scale_nominal - JMS_sf[self.year][1]
+            # get back raw mass with nominal scale and rescale it
+            new_mass = (mass / scale_nominal) * scale_var
+        return new_mass
+
+    def smearFatJetMass(self, mass, current_smear, kind):
+        res_MC = JMR_MC[self.year]
+        res_SF_central = JMR_sf[self.year][0]
+
+        if kind == "Central":
+            if res_SF_central > 1: 
+                sigma_MC = self.rnd.Gaus(0, res_MC)
+                smearfactor = 1 + (sigma_MC/mass)* sqrt(res_SF_central**2 - 1) 
+            else:
+                smearfactor = 1
+            # the base mass is the current one
+            raw_mass = mass
+        else:
+            if kind == "Up":
+                res_SF_var = res_SF_central + JMR_sf[self.year][1]
+            elif kind == "Down":
+                res_SF_var = res_SF_central - JMR_sf[self.year][1]
+            # get the base smearing given by resolution at the beginning
+            # This is Gaus(0, res_MC) used for nominal smearing (relative to nominal (scaled) mass)
+            raw_mass = mass / current_smear
+            sigma_MC_relative = (current_smear -1)  / ( sqrt(res_SF_central**2 -1))
+            
+            if res_SF_var > 1:
+                smearfactor = 1 + sigma_MC_relative*sqrt(res_SF_var**2 - 1)
+            else:
+                smearfactor = 1
+
+        print "smear factor: ", smearfactor
+        new_mass = raw_mass * smearfactor
+
+        return new_mass, smearfactor

--- a/NanoGardener/python/modules/FatJetMassScaler.py
+++ b/NanoGardener/python/modules/FatJetMassScaler.py
@@ -121,7 +121,7 @@ class FatJetMassScaler(Module):
             else:
                 smearfactor = 1
 
-        print "smear factor: ", smearfactor
+        #print "smear factor: ", smearfactor
         new_mass = raw_mass * smearfactor
 
         return new_mass, smearfactor


### PR DESCRIPTION
Added module to scale and smear the FatJet mass according to https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetWtagging#2017_scale_factors_and_correctio. 
The module can also be used to compute variations.

Scale factors for the High Purity (HP) category have been added in the cfg file NanoGardener/python/data/FatJetMaker_cfg.py
