### PR TITLE
Removed signal / control region definition from HMlnjjVars module

### DIFF
--- a/NanoGardener/python/modules/HMlnjjVars.py
+++ b/NanoGardener/python/modules/HMlnjjVars.py
@@ -48,27 +48,15 @@ class HMlnjjVarsClass(Module):
 
         self.out.branch("Flavlnjj" , "I")
 
-        list_myvar=['IsBoostedSR','IsBoostedSB','IsBoostedTopCR',
-                    'IsResolvedSR','IsResolvedSB','IsResolvedTopCR']
-        self.out.branch("IsBoostedTopCR" , "O")
-        self.out.branch("IsBoostedSR" , "O")
-        self.out.branch("IsBoostedSB"  , "O")
 
-        self.out.branch("IsResolvedTopCR" , "O")
-        self.out.branch("IsResolvedSR" , "O")
-        self.out.branch("IsResolvedSB"  , "O")
-
+        self.out.branch("IsBoosted", "O")
+        self.out.branch("IsResolved", "O")
+        self.out.branch("IsTopTagged", "O")
 
         ##For Boosted Selection ##For FatJet
         list_myvar=['pt','eta','phi','mass','tau21','WptOvHfatM','HlnFat_mass']
         for myvar in list_myvar:
-
-            self.out.branch("CleanFatJetPassMBoostedSR_"+myvar, 'F', lenVar='nCleanFatJetPassMBoostedSR')
-            self.out.branch("CleanFatJetPassMBoostedSB_"+myvar, 'F', lenVar='nCleanFatJetPassMBoostedSB')
-
-
-
-
+            self.out.branch("CleanFatJetPassMBoosted_"+myvar, 'F', lenVar='nCleanFatJetPassMBoosted')
 
 
 
@@ -114,34 +102,26 @@ class HMlnjjVarsClass(Module):
 
         ##--For FatJet Collection in SR/SB/TopCR
         list_myvar=['pt','eta','phi','mass','tau21','WptOvHfatM','HlnFat_mass']
-        CleanFatJetPassMBoostedSR={}
-        CleanFatJetPassMBoostedSB={}
-        #CleanFatJetPassBoostedTopCR={}
+        CleanFatJetPassMBoosted={}
         for myvar in list_myvar:
-            CleanFatJetPassMBoostedSR[myvar]=[]
-            CleanFatJetPassMBoostedSB[myvar]=[]
+            CleanFatJetPassMBoosted[myvar]=[]
 
 
 
-        Wfat_SR   = False
-        Wfat_SB   = False
-        Wfat_Btop = False
-        Wjj_Btop  = False
+        Evt_btagged = False
 
         Hlnjj_mass = -999.
         WptOvHak4M = -999
 
-        Wjj_SR     = False
-        Wjj_SB     = False
-        Wjj_Btop   = False
+        IsWfat = False
+        IsWjj  = False
 
         Wlep_mt  = -999
         Hlnjj_mt = -999
 
         ##Event variable
         EventVar={}
-        list_myvar=['IsBoostedSR','IsBoostedSB','IsBoostedTopCR','IsResolvedSR',
-                    'IsResolvedSB','IsResolvedTopCR','IsVbfFat','IsVbfjj']
+        list_myvar=['IsBoosted','IsResolved','IsTopTagged','IsVbfFat','IsVbfjj']
         for myvar in list_myvar:
             EventVar[myvar]=False
 
@@ -150,13 +130,9 @@ class HMlnjjVarsClass(Module):
         vbfjj_jj_dEta  = -999
         vbfjj_jj_mass  = -999
 
-        IsFatSig = False
-        IsFatSB  = False
-        IsFatTop = False
 
-        IsJjSig  = False
-        IsJjSB   = False
-        IsJjTop  = False
+        IsFat = False
+        IsJj  = False
 
         IsVbfFat = False
         IsVbfjj  = False
@@ -204,14 +180,14 @@ class HMlnjjVarsClass(Module):
                             )
 
         ##Check btagged event or not
-
+        # FIXME: loop over CleanJetNotFat or all CleanJet?
         bWP=self.bWP
         for jdx in range( CleanJetNotFat_col._len ):
             clj_idx = CleanJetNotFat_col[jdx]['jetIdx']
             jet_idx = CJet_col[ clj_idx ]['jetIdx']
             if Jet_col[ jet_idx ]['btagDeepB'] > bWP:
               if Jet_col[ jet_idx ]['pt'] > 20:
-                Wfat_Btop = True
+                Evt_btagged = True
 
 
 
@@ -241,36 +217,21 @@ class HMlnjjVarsClass(Module):
               ##https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetWtagging#2016_scale_factors_and_correctio , high purity cut
             cutJ_base = [Wfat_pt > 200, abs(Wfat_eta)<2.4,
                          Wfat_tau21 < self.tau21WP, thisWptOvHfatM > 0.4]
-            #cutJ_base = [ Wfat_pt > 200 abs(Wfat_eta)<2.4, Wfat_mass < 250, Wfat_mass > 40]
-            if not all(cutJ_base) : continue
-            # Let's stop the loop here, passing cutJ_base, then it become a Sig or a SB for a event.
-            cutJ_SB   = [ Wfat_mass > 40, Wfat_mass < 250]
-            cutJ_SR  = [ Wfat_mass >= 65, Wfat_mass <= 105]
-            if all(cutJ_SR): ##pass SR msoftdrop cut
-                ##Need to use dic type
-                CleanFatJetPassMBoostedSR['pt'].append(Wfat_pt)
-                CleanFatJetPassMBoostedSR['mass'].append(Wfat_mass)
-                CleanFatJetPassMBoostedSR['eta'].append(Wfat_eta)
-                CleanFatJetPassMBoostedSR['phi'].append(Wfat_phi)
-                CleanFatJetPassMBoostedSR['tau21'].append(Wfat_tau21)
-                CleanFatJetPassMBoostedSR['WptOvHfatM'].append(thisWptOvHfatM)
-                CleanFatJetPassMBoostedSR['HlnFat_mass'].append(thisHlnFat_mass)
+            if  all(cutJ_base):
+                CleanFatJetPassMBoosted['pt'].append(Wfat_pt)
+                CleanFatJetPassMBoosted['mass'].append(Wfat_mass)
+                CleanFatJetPassMBoosted['eta'].append(Wfat_eta)
+                CleanFatJetPassMBoosted['phi'].append(Wfat_phi)
+                CleanFatJetPassMBoosted['tau21'].append(Wfat_tau21)
+                CleanFatJetPassMBoosted['WptOvHfatM'].append(thisWptOvHfatM)
+                CleanFatJetPassMBoosted['HlnFat_mass'].append(thisHlnFat_mass)
 
-            elif all(cutJ_SB): ##pass SB msoftdrop cut
 
-                CleanFatJetPassMBoostedSB['pt'].append(Wfat_pt)
-                CleanFatJetPassMBoostedSB['mass'].append(Wfat_mass)
-                CleanFatJetPassMBoostedSB['eta'].append(Wfat_eta)
-                CleanFatJetPassMBoostedSB['phi'].append(Wfat_phi)
-                CleanFatJetPassMBoostedSB['tau21'].append(Wfat_tau21)
-                CleanFatJetPassMBoostedSB['WptOvHfatM'].append(thisWptOvHfatM)
-                CleanFatJetPassMBoostedSB['HlnFat_mass'].append(thisHlnFat_mass)
+        IsWfat=(len(CleanFatJetPassMBoosted['pt']) > 0 )
 
-        Wfat_SR=(len(CleanFatJetPassMBoostedSR['pt']) > 0 )
-        Wfat_SB=(len(CleanFatJetPassMBoostedSB['pt']) > 0 )
         # W_Ak4 Event ----------------------------
         #if (Wfat_SR == False or Wfat_Btop == True) and (Wjj_mass > -1):
-        if ( ( not Wfat_SR ) and ((Wjj_ClJet0_idx != -1) or (Wjj_ClJet1_idx != -1)) ) : ##No FatJet passing final boosted cut and no resolved Whad candidate
+        if ( ( not IsWfat ) and ((Wjj_ClJet0_idx != -1) and (Wjj_ClJet1_idx != -1)) ) : ##No FatJet passing final boosted cut and it is resolved Whad candidate
             # Now it is Wjj event, initialize as all is true
 
             self.Wjj_4v.SetPtEtaPhiM(Wjj_pt, Wjj_eta, Wjj_phi, Wjj_mass)
@@ -284,21 +245,7 @@ class HMlnjjVarsClass(Module):
 
             #cutjj_Base = [ met_pt>30, Wlep_mt>50, Hlnjj_mt > 60, WptOvHak4M > 0.35 ]
             cutjj_Base = [ Wlep_mt>50, Wjj_mass > 40 and Wjj_mass < 250, Hlnjj_mt > 60, WptOvHak4M > 0.35 ]
-            cutjj_SR  = [ Wjj_mass > 65 and Wjj_mass < 105 ]
-            cutjj_SB  = [   (Wjj_mass >  40 and Wjj_mass <  65)
-                         or (Wjj_mass > 105 and Wjj_mass < 250) ]
-
-            if all(cutjj_Base) and all(cutjj_SR) : Wjj_SR = True
-            if all(cutjj_Base) and all(cutjj_SB) : Wjj_SB = True
-
-            JetIdx0 = CJet_col[Wjj_ClJet0_idx]['jetIdx']
-            JetIdx1 = CJet_col[Wjj_ClJet1_idx]['jetIdx']
-            for jdx in range(Jet_col._len):
-                if jdx == JetIdx0: continue
-                if jdx == JetIdx1: continue
-                if Jet_col[jdx]['pt'] < 20: continue
-                if abs(Jet_col[jdx]['eta']) > 2.4: continue
-                if Jet_col[jdx]['btagDeepB'] > bWP: Wjj_Btop = True
+            IsWjj = all(cutjj_Base)
 
 
 
@@ -308,30 +255,16 @@ class HMlnjjVarsClass(Module):
 
         # Save Event ---------------------------------
         # Evet Catagory
-        Cat_Fat_Btop= [Wfat_SR == True, Wfat_Btop == True, met_pt > 40]
-        Cat_Fat_Sig = [Wfat_SR == True, Wfat_Btop == False, met_pt > 40]
-        Cat_Fat_SB  = [Wfat_SB  == True, Wfat_Btop == False, met_pt > 40]
+        Cat_Fat = [IsWfat, met_pt > 40]
+        IsFat = all(Cat_Fat)
+
+        Cat_AK4     = [IsWjj, met_pt > 30]
+        isJj = all(Cat_AK4)
 
 
-        if all(Cat_Fat_Sig) : IsFatSig = True
-        if all(Cat_Fat_SB)  : IsFatSB  = True
-        if all(Cat_Fat_Btop): IsFatTop = True
-
-        Cat_AK4_Btop= [Wjj_SR == True, Wjj_Btop == True, met_pt >30]
-        Cat_AK4_Sig = [Wjj_SR == True, Wjj_Btop == False, met_pt > 30]
-        Cat_AK4_SB  = [Wjj_SB  == True, Wjj_Btop == False, met_pt > 30]
-
-        if all(Cat_AK4_Sig) : IsJjSig = True
-        if all(Cat_AK4_SB)  : IsJjSB  = True
-        if all(Cat_AK4_Btop): IsJjTop = True
-
-        EventVar['IsBoostedSR'] = IsFatSig
-        EventVar['IsBoostedSB'] = IsFatSB
-        EventVar['IsBoostedTopCR'] = IsFatTop
-
-        EventVar['IsResolvedSR'] = IsJjSig
-        EventVar['IsResolvedSB'] = IsJjSB
-        EventVar['IsResolvedTopCR'] = IsJjTop
+        EventVar['IsBoosted'] = isFat
+        EventVar['IsResolved'] = IsJj
+        EventVar['IsTopTagged'] = Evt_btagged
 
 
         # VBF tag ---------------------------------------
@@ -346,7 +279,7 @@ class HMlnjjVarsClass(Module):
         lnJ_addJet_jid = []
 
         nlnJ_addJet = 0
-        if IsFatSig or IsFatSB or IsFatTop:
+        if IsFat:
             for jdx in range(CleanJetNotFat_col._len):
                 clj_i = CleanJetNotFat_col[jdx]['jetIdx']
                 if ( CJet_col[clj_i]['pt'] < 30 ) or ( abs(CJet_col[clj_i]['eta'])>4.7 ): continue
@@ -380,7 +313,7 @@ class HMlnjjVarsClass(Module):
         lnjj_addJet_mass = []
         lnjj_addJet_jid = []
         nlnjj_addJet = 0
-        if IsJjSig or IsJjSB or IsJjTop:
+        if IsJj:
             for ci in range(CJet_col._len):
                 # check if it is used
                 if ci == Wjj_ClJet0_idx : continue
@@ -413,22 +346,18 @@ class HMlnjjVarsClass(Module):
 
 
 
-        if IsFatSig==False and IsFatSB==False and IsFatTop==False and IsJjSig==False and IsJjSB==False and IsJjTop==False:
-            return False
-
 
 
         self.out.fillBranch( 'Flavlnjj' , Flavlnjj)
         ##--Event Categorization--##
-        list_myvar=['IsBoostedSR','IsBoostedSB','IsBoostedTopCR','IsResolvedSR','IsResolvedSB','IsResolvedTopCR','IsVbfFat','IsVbfjj']
+        list_myvar=['IsBoosted','IsResolved','IsTopTagged','IsVbfFat','IsVbfjj']
         for myvar in list_myvar:
             self.out.fillBranch( myvar, EventVar[myvar] )
 
         ##--Boosted FatJet--##
         list_myvar=['pt','eta','phi','mass','tau21','WptOvHfatM','HlnFat_mass']
         for myvar in list_myvar:
-            self.out.fillBranch( "CleanFatJetPassMBoostedSR_"+myvar , CleanFatJetPassMBoostedSR[myvar])
-            self.out.fillBranch( "CleanFatJetPassMBoostedSB_"+myvar , CleanFatJetPassMBoostedSB[myvar])
+            self.out.fillBranch( "CleanFatJetPassMBoosted_"+myvar , CleanFatJetPassMBoosted[myvar])
 
 
 

--- a/NanoGardener/python/modules/HMlnjjVars.py
+++ b/NanoGardener/python/modules/HMlnjjVars.py
@@ -12,20 +12,20 @@ Wmass=80.4
 
 class HMlnjjVarsClass(Module):
     def __init__(self,year):
-	self.HlnFat_4v  = ROOT.TLorentzVector()
-	self.Hlnjj_4v   = ROOT.TLorentzVector()
-	self.Wlep_4v   = ROOT.TLorentzVector()
-	self.Wfat_4v   = ROOT.TLorentzVector()
-	self.Wjj_4v   = ROOT.TLorentzVector()
+    self.HlnFat_4v  = ROOT.TLorentzVector()
+    self.Hlnjj_4v   = ROOT.TLorentzVector()
+    self.Wlep_4v   = ROOT.TLorentzVector()
+    self.Wfat_4v   = ROOT.TLorentzVector()
+    self.Wjj_4v   = ROOT.TLorentzVector()
         print "@@Year->",year
         self.year=year
         # b-tag WP && tau21 (Wtag)
         self.bWP=0.2217 ##2016legacy
         self.tau21WP=0.4 ##2016 legacy
-        if '2016' in str(self.year): 
+        if '2016' in str(self.year):
             self.bWP=0.2217   ##https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation2016Legacy
             self.tau21WP=0.4  ##2016 scale factors and corrections
-        elif '2017' in str(self.year): 
+        elif '2017' in str(self.year):
             self.bWP=0.1522    ##https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X
             self.tau21WP=0.45  ##https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetWtagging#tau21_0_45
         elif '2018' in str(self.year):
@@ -33,7 +33,7 @@ class HMlnjjVarsClass(Module):
             self.tau21WP=0.45  ##https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetWtagging#tau21_0_45_HP_0_45_tau21_0_75_LP
 
         # tau21 cut (High purity)
-        
+
 
     def beginJob(self):
         pass
@@ -48,7 +48,8 @@ class HMlnjjVarsClass(Module):
 
         self.out.branch("Flavlnjj" , "I")
 
-        list_myvar=['IsBoostedSR','IsBoostedSB','IsBoostedTopCR','IsResolvedSR','IsResolvedSB','IsResolvedTopCR']
+        list_myvar=['IsBoostedSR','IsBoostedSB','IsBoostedTopCR',
+                    'IsResolvedSR','IsResolvedSB','IsResolvedTopCR']
         self.out.branch("IsBoostedTopCR" , "O")
         self.out.branch("IsBoostedSR" , "O")
         self.out.branch("IsBoostedSB"  , "O")
@@ -60,21 +61,21 @@ class HMlnjjVarsClass(Module):
 
         ##For Boosted Selection ##For FatJet
         list_myvar=['pt','eta','phi','mass','tau21','WptOvHfatM','HlnFat_mass']
-        for myvar in list_myvar: 
-            
+        for myvar in list_myvar:
+
             self.out.branch("CleanFatJetPassMBoostedSR_"+myvar, 'F', lenVar='nCleanFatJetPassMBoostedSR')
             self.out.branch("CleanFatJetPassMBoostedSB_"+myvar, 'F', lenVar='nCleanFatJetPassMBoostedSB')
-            
 
 
-        
-
-        
-        
-        
 
 
-        self.out.branch("WptOvHak4M", "F")        
+
+
+
+
+
+
+        self.out.branch("WptOvHak4M", "F")
         self.out.branch("Hlnjj_mass" , "F")
         self.out.branch("Wlep_mt" , "F")
         self.out.branch("Hlnjj_mt" , "F")
@@ -99,17 +100,17 @@ class HMlnjjVarsClass(Module):
     def analyze(self, event):
         """process event, return True (go to next module) or False (fail, go to next event)"""
         # do this check at every event, as other modules might have read further branches
-        #if event._tree._ttreereaderversion > self._ttreereaderversion: 
+        #if event._tree._ttreereaderversion > self._ttreereaderversion:
         #    self.initReaders(event._tree)
         #nOrgJets = getattr(event, "nJet")
         #OrgJets = Collection(event, "Jet")
 
-	# initialize
-	self.HlnFat_4v.SetPtEtaPhiM(0,0,0,0)
-	self.Hlnjj_4v.SetPtEtaPhiM(0,0,0,0)
-	self.Wlep_4v.SetPtEtaPhiM(0,0,0,0)
-	self.Wfat_4v.SetPtEtaPhiM(0,0,0,0)
-	self.Wjj_4v.SetPtEtaPhiM(0,0,0,0)
+        # initialize
+        self.HlnFat_4v.SetPtEtaPhiM(0,0,0,0)
+        self.Hlnjj_4v.SetPtEtaPhiM(0,0,0,0)
+        self.Wlep_4v.SetPtEtaPhiM(0,0,0,0)
+        self.Wfat_4v.SetPtEtaPhiM(0,0,0,0)
+        self.Wjj_4v.SetPtEtaPhiM(0,0,0,0)
 
         ##--For FatJet Collection in SR/SB/TopCR
         list_myvar=['pt','eta','phi','mass','tau21','WptOvHfatM','HlnFat_mass']
@@ -119,60 +120,56 @@ class HMlnjjVarsClass(Module):
         for myvar in list_myvar:
             CleanFatJetPassMBoostedSR[myvar]=[]
             CleanFatJetPassMBoostedSB[myvar]=[]
-            
 
 
-        Wfat_SR = False
-        Wfat_SB = False
+
+        Wfat_SR   = False
+        Wfat_SB   = False
         Wfat_Btop = False
-        Wjj_Btop = False
-	
-	Hlnjj_mass = -999.
-	WptOvHak4M = -999
+        Wjj_Btop  = False
 
-	Wjj_SR     = False
-	Wjj_SB      = False
-	Wjj_Btop    = False
+        Hlnjj_mass = -999.
+        WptOvHak4M = -999
 
-	Wlep_mt = -999
-	Hlnjj_mt = -999
+        Wjj_SR     = False
+        Wjj_SB     = False
+        Wjj_Btop   = False
+
+        Wlep_mt  = -999
+        Hlnjj_mt = -999
 
         ##Event variable
         EventVar={}
-        list_myvar=['IsBoostedSR','IsBoostedSB','IsBoostedTopCR','IsResolvedSR','IsResolvedSB','IsResolvedTopCR','IsVbfFat','IsVbfjj']
+        list_myvar=['IsBoostedSR','IsBoostedSB','IsBoostedTopCR','IsResolvedSR',
+                    'IsResolvedSB','IsResolvedTopCR','IsVbfFat','IsVbfjj']
         for myvar in list_myvar:
             EventVar[myvar]=False
 
-	vbfFat_jj_dEta = -999
-	vbfFat_jj_mass = -999
-	vbfjj_jj_dEta = -999
-	vbfjj_jj_mass = -999
+        vbfFat_jj_dEta = -999
+        vbfFat_jj_mass = -999
+        vbfjj_jj_dEta  = -999
+        vbfjj_jj_mass  = -999
 
         IsFatSig = False
-        IsFatSB = False
+        IsFatSB  = False
         IsFatTop = False
-        
-        IsJjSig = False
-        IsJjSB = False
-        IsJjTop = False
+
+        IsJjSig  = False
+        IsJjSB   = False
+        IsJjTop  = False
 
         IsVbfFat = False
-        IsVbfjj = False
-        
+        IsVbfjj  = False
+
 
 
         ##--read vars
 
-        Lept_col        = Collection(event, 'Lepton')
-
-        CFatJet_col		= Collection(event, 'CleanFatJet')
-
-	CJet_col		= Collection(event, 'CleanJet')
-
-        CleanJetNotFat_col      = Collection(event, "CleanJetNotFat")
-
-
-	Jet_col		= Collection(event, 'Jet')
+        Lept_col           = Collection(event, 'Lepton')
+        CFatJet_col        = Collection(event, 'CleanFatJet')
+        CJet_col           = Collection(event, 'CleanJet')
+        CleanJetNotFat_col = Collection(event, 'CleanJetNotFat')
+        Jet_col            = Collection(event, 'Jet')
 
         met_pt         = getattr(event, "MET_pt")
 
@@ -181,150 +178,152 @@ class HMlnjjVarsClass(Module):
         Wlep_phi_PF   = getattr(event, "Wlep_phi_PF")
         Wlep_mass_PF  = getattr(event,"Wlep_mass_PF")
 
-        Wjj_pt	= getattr(event,"Whad_pt")
-        Wjj_eta	= getattr(event,"Whad_eta")
-        Wjj_phi	= getattr(event,"Whad_phi")
-        Wjj_mass	= getattr(event,"Whad_mass")
-        
+        Wjj_pt     = getattr(event,"Whad_pt")
+        Wjj_eta    = getattr(event,"Whad_eta")
+        Wjj_phi    = getattr(event,"Whad_phi")
+        Wjj_mass   = getattr(event,"Whad_mass")
+
         Wjj_ClJet0_idx= getattr(event, "idx_j1")
         Wjj_ClJet1_idx= getattr(event, "idx_j2")
 
 
 
-        
 
 
-	if Lept_col._len < 1: return False
-	Flavlnjj  = -999
-	if abs(Lept_col[0]['pdgId']) == 11 : Flavlnjj = 1
-	if abs(Lept_col[0]['pdgId']) == 13 : Flavlnjj = 2
+
+        if Lept_col._len < 1: return False
+        Flavlnjj  = -999
+        if abs(Lept_col[0]['pdgId']) == 11 : Flavlnjj = 1
+        if abs(Lept_col[0]['pdgId']) == 13 : Flavlnjj = 2
 
 
-	self.Wlep_4v.SetPtEtaPhiM(Wlep_pt_PF,
-	                           Wlep_eta_PF,
-	                           Wlep_phi_PF,
-	                           Wlep_mass_PF
-				   )
+        self.Wlep_4v.SetPtEtaPhiM(Wlep_pt_PF,
+                               Wlep_eta_PF,
+                               Wlep_phi_PF,
+                               Wlep_mass_PF
+                            )
 
         ##Check btagged event or not
 
-        bWP=self.bWP  
+        bWP=self.bWP
         for jdx in range( CleanJetNotFat_col._len ):
             clj_idx = CleanJetNotFat_col[jdx]['jetIdx']
             jet_idx = CJet_col[ clj_idx ]['jetIdx']
-	    if Jet_col[ jet_idx ]['btagDeepB'] > bWP:
-	      if Jet_col[ jet_idx ]['pt'] > 20:
-	        Wfat_Btop = True 
+            if Jet_col[ jet_idx ]['btagDeepB'] > bWP:
+              if Jet_col[ jet_idx ]['pt'] > 20:
+                Wfat_Btop = True
 
 
 
 
 
-	# FatJet evet from FatJet module , but need to apply cut further
+        # FatJet event from FatJet module, but need to apply cut further
 
-        
-	for ix in range( CFatJet_col._len ):
 
-	  Wfat_mass = CFatJet_col[ix]['mass']
-	  Wfat_pt   = CFatJet_col[ix]['pt']
-	  Wfat_eta  = CFatJet_col[ix]['eta']
-	  Wfat_phi  = CFatJet_col[ix]['phi']
-	  Wfat_tau21= CFatJet_col[ix]['tau21']
+        for ix in range( CFatJet_col._len ):
 
-	  self.Wfat_4v.SetPtEtaPhiM(Wfat_pt, Wfat_eta, Wfat_phi, Wfat_mass)
+            Wfat_mass = CFatJet_col[ix]['mass']
+            Wfat_pt   = CFatJet_col[ix]['pt']
+            Wfat_eta  = CFatJet_col[ix]['eta']
+            Wfat_phi  = CFatJet_col[ix]['phi']
+            Wfat_tau21= CFatJet_col[ix]['tau21']
 
-	  self.HlnFat_4v = self.Wfat_4v + self.Wlep_4v 
-	  thisHlnFat_mass = self.HlnFat_4v.M()
+            self.Wfat_4v.SetPtEtaPhiM(Wfat_pt, Wfat_eta, Wfat_phi, Wfat_mass)
 
-	  thisWptOvHfatM = min(Wlep_pt_PF, Wfat_pt)/thisHlnFat_mass
+            self.HlnFat_4v = self.Wfat_4v + self.Wlep_4v
+            thisHlnFat_mass = self.HlnFat_4v.M()
 
-	  # FatJet Evt Cuts
-          # These are already selected in postproduction but to make sure
-	  # N-subjettiness tau21 = tau2/tau1
-          ##https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetWtagging#2016_scale_factors_and_correctio , high purity cut
-	  cutJ_base = [ Wfat_pt > 200,abs(Wfat_eta)<2.4, Wfat_tau21 < self.tau21WP, thisWptOvHfatM > 0.4]
-          #cutJ_base = [ Wfat_pt > 200 abs(Wfat_eta)<2.4, Wfat_mass < 250, Wfat_mass > 40]
-	  if not all(cutJ_base) : continue
-	  # Let's stop the loop here, passing cutJ_base, then it become a Sig or a SB for a event.
-	  cutJ_SB   = [ Wfat_mass > 40, Wfat_mass < 250]
-	  cutJ_SR  = [ Wfat_mass >= 65, Wfat_mass <= 105]
-          if all(cutJ_SR): ##pass SR msoftdrop cut
-              ##Need to use dic type
-              CleanFatJetPassMBoostedSR['pt'].append(Wfat_pt)
-              CleanFatJetPassMBoostedSR['mass'].append(Wfat_mass)
-              CleanFatJetPassMBoostedSR['eta'].append(Wfat_eta)
-              CleanFatJetPassMBoostedSR['phi'].append(Wfat_phi)
-              CleanFatJetPassMBoostedSR['tau21'].append(Wfat_tau21)
-              CleanFatJetPassMBoostedSR['WptOvHfatM'].append(thisWptOvHfatM)
-              CleanFatJetPassMBoostedSR['HlnFat_mass'].append(thisHlnFat_mass)
-              
-          elif all(cutJ_SB): ##pass SB msoftdrop cut
-              
-              CleanFatJetPassMBoostedSB['pt'].append(Wfat_pt)
-              CleanFatJetPassMBoostedSB['mass'].append(Wfat_mass)
-              CleanFatJetPassMBoostedSB['eta'].append(Wfat_eta)
-              CleanFatJetPassMBoostedSB['phi'].append(Wfat_phi)
-              CleanFatJetPassMBoostedSB['tau21'].append(Wfat_tau21)
-              CleanFatJetPassMBoostedSB['WptOvHfatM'].append(thisWptOvHfatM)
-              CleanFatJetPassMBoostedSB['HlnFat_mass'].append(thisHlnFat_mass)
+            thisWptOvHfatM = min(Wlep_pt_PF, Wfat_pt)/thisHlnFat_mass
+
+            # FatJet Evt Cuts
+              # These are already selected in postproduction but to make sure
+            # N-subjettiness tau21 = tau2/tau1
+              ##https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetWtagging#2016_scale_factors_and_correctio , high purity cut
+            cutJ_base = [Wfat_pt > 200, abs(Wfat_eta)<2.4,
+                         Wfat_tau21 < self.tau21WP, thisWptOvHfatM > 0.4]
+            #cutJ_base = [ Wfat_pt > 200 abs(Wfat_eta)<2.4, Wfat_mass < 250, Wfat_mass > 40]
+            if not all(cutJ_base) : continue
+            # Let's stop the loop here, passing cutJ_base, then it become a Sig or a SB for a event.
+            cutJ_SB   = [ Wfat_mass > 40, Wfat_mass < 250]
+            cutJ_SR  = [ Wfat_mass >= 65, Wfat_mass <= 105]
+            if all(cutJ_SR): ##pass SR msoftdrop cut
+                ##Need to use dic type
+                CleanFatJetPassMBoostedSR['pt'].append(Wfat_pt)
+                CleanFatJetPassMBoostedSR['mass'].append(Wfat_mass)
+                CleanFatJetPassMBoostedSR['eta'].append(Wfat_eta)
+                CleanFatJetPassMBoostedSR['phi'].append(Wfat_phi)
+                CleanFatJetPassMBoostedSR['tau21'].append(Wfat_tau21)
+                CleanFatJetPassMBoostedSR['WptOvHfatM'].append(thisWptOvHfatM)
+                CleanFatJetPassMBoostedSR['HlnFat_mass'].append(thisHlnFat_mass)
+
+            elif all(cutJ_SB): ##pass SB msoftdrop cut
+
+                CleanFatJetPassMBoostedSB['pt'].append(Wfat_pt)
+                CleanFatJetPassMBoostedSB['mass'].append(Wfat_mass)
+                CleanFatJetPassMBoostedSB['eta'].append(Wfat_eta)
+                CleanFatJetPassMBoostedSB['phi'].append(Wfat_phi)
+                CleanFatJetPassMBoostedSB['tau21'].append(Wfat_tau21)
+                CleanFatJetPassMBoostedSB['WptOvHfatM'].append(thisWptOvHfatM)
+                CleanFatJetPassMBoostedSB['HlnFat_mass'].append(thisHlnFat_mass)
 
         Wfat_SR=(len(CleanFatJetPassMBoostedSR['pt']) > 0 )
         Wfat_SB=(len(CleanFatJetPassMBoostedSB['pt']) > 0 )
         # W_Ak4 Event ----------------------------
-	#if (Wfat_SR == False or Wfat_Btop == True) and (Wjj_mass > -1):
+        #if (Wfat_SR == False or Wfat_Btop == True) and (Wjj_mass > -1):
         if ( ( not Wfat_SR ) and ((Wjj_ClJet0_idx != -1) or (Wjj_ClJet1_idx != -1)) ) : ##No FatJet passing final boosted cut and no resolved Whad candidate
-	  # Now it is Wjj event, initialize as all is true
+            # Now it is Wjj event, initialize as all is true
 
-	  self.Wjj_4v.SetPtEtaPhiM(Wjj_pt, Wjj_eta, Wjj_phi, Wjj_mass)
-	  self.Hlnjj_4v = self.Wlep_4v + self.Wjj_4v
+            self.Wjj_4v.SetPtEtaPhiM(Wjj_pt, Wjj_eta, Wjj_phi, Wjj_mass)
+            self.Hlnjj_4v = self.Wlep_4v + self.Wjj_4v
 
-	  Hlnjj_mass = self.Hlnjj_4v.M()
-	  Hlnjj_mt = self.Hlnjj_4v.Mt()
-	  WptOvHak4M = min(Wlep_pt_PF, Wjj_pt)/Hlnjj_mass
+            Hlnjj_mass = self.Hlnjj_4v.M()
+            Hlnjj_mt = self.Hlnjj_4v.Mt()
+            WptOvHak4M = min(Wlep_pt_PF, Wjj_pt)/Hlnjj_mass
 
-          Wlep_mt =  self.Wlep_4v.Mt()
+            Wlep_mt =  self.Wlep_4v.Mt()
 
-          #cutjj_Base = [ met_pt>30, Wlep_mt>50, Hlnjj_mt > 60, WptOvHak4M > 0.35 ]
-          cutjj_Base = [ Wlep_mt>50, Wjj_mass > 40 and Wjj_mass < 250, Hlnjj_mt > 60, WptOvHak4M > 0.35 ]
-	  cutjj_SR  = [ Wjj_mass > 65 and Wjj_mass < 105 ]
-          cutjj_SB  = [ ( Wjj_mass > 40 and Wjj_mass < 65) or (Wjj_mass > 105 and Wjj_mass < 250 ) ]
-            
-          if all(cutjj_Base) and all(cutjj_SR) : Wjj_SR = True
-	  if all(cutjj_Base) and all(cutjj_SB) : Wjj_SB = True
+            #cutjj_Base = [ met_pt>30, Wlep_mt>50, Hlnjj_mt > 60, WptOvHak4M > 0.35 ]
+            cutjj_Base = [ Wlep_mt>50, Wjj_mass > 40 and Wjj_mass < 250, Hlnjj_mt > 60, WptOvHak4M > 0.35 ]
+            cutjj_SR  = [ Wjj_mass > 65 and Wjj_mass < 105 ]
+            cutjj_SB  = [   (Wjj_mass >  40 and Wjj_mass <  65)
+                         or (Wjj_mass > 105 and Wjj_mass < 250) ]
 
-          JetIdx0 = CJet_col[Wjj_ClJet0_idx]['jetIdx']
-          JetIdx1 = CJet_col[Wjj_ClJet1_idx]['jetIdx']
-          for jdx in range(Jet_col._len):
-	    if jdx == JetIdx0: continue
-	    if jdx == JetIdx1: continue
-	    if Jet_col[jdx]['pt'] < 20: continue
-	    if abs(Jet_col[jdx]['eta']) > 2.4: continue
-	    if Jet_col[jdx]['btagDeepB'] > bWP: Wjj_Btop = True
+            if all(cutjj_Base) and all(cutjj_SR) : Wjj_SR = True
+            if all(cutjj_Base) and all(cutjj_SB) : Wjj_SB = True
 
-
-
+            JetIdx0 = CJet_col[Wjj_ClJet0_idx]['jetIdx']
+            JetIdx1 = CJet_col[Wjj_ClJet1_idx]['jetIdx']
+            for jdx in range(Jet_col._len):
+                if jdx == JetIdx0: continue
+                if jdx == JetIdx1: continue
+                if Jet_col[jdx]['pt'] < 20: continue
+                if abs(Jet_col[jdx]['eta']) > 2.4: continue
+                if Jet_col[jdx]['btagDeepB'] > bWP: Wjj_Btop = True
 
 
 
 
-	# Save Event ---------------------------------
-	# Evet Catagory
+
+
+
+        # Save Event ---------------------------------
+        # Evet Catagory
         Cat_Fat_Btop= [Wfat_SR == True, Wfat_Btop == True, met_pt > 40]
         Cat_Fat_Sig = [Wfat_SR == True, Wfat_Btop == False, met_pt > 40]
         Cat_Fat_SB  = [Wfat_SB  == True, Wfat_Btop == False, met_pt > 40]
-        
 
-	if all(Cat_Fat_Sig) : IsFatSig = True
-	if all(Cat_Fat_SB)  : IsFatSB  = True
-	if all(Cat_Fat_Btop): IsFatTop = True
+
+        if all(Cat_Fat_Sig) : IsFatSig = True
+        if all(Cat_Fat_SB)  : IsFatSB  = True
+        if all(Cat_Fat_Btop): IsFatTop = True
 
         Cat_AK4_Btop= [Wjj_SR == True, Wjj_Btop == True, met_pt >30]
         Cat_AK4_Sig = [Wjj_SR == True, Wjj_Btop == False, met_pt > 30]
         Cat_AK4_SB  = [Wjj_SB  == True, Wjj_Btop == False, met_pt > 30]
 
-	if all(Cat_AK4_Sig) : IsJjSig = True
-	if all(Cat_AK4_SB)  : IsJjSB  = True
-	if all(Cat_AK4_Btop): IsJjTop = True
+        if all(Cat_AK4_Sig) : IsJjSig = True
+        if all(Cat_AK4_SB)  : IsJjSB  = True
+        if all(Cat_AK4_Btop): IsJjTop = True
 
         EventVar['IsBoostedSR'] = IsFatSig
         EventVar['IsBoostedSB'] = IsFatSB
@@ -335,83 +334,88 @@ class HMlnjjVarsClass(Module):
         EventVar['IsResolvedTopCR'] = IsJjTop
 
 
-	# VBF tag ---------------------------------------
-	# Requiring two additional jets with pt > 30 gev, |eta| < 4.7
-	# and VBF cuts
-        
-	# lnJ case--------
+        # VBF tag ---------------------------------------
+        # Requiring two additional jets with pt > 30 gev, |eta| < 4.7
+        # and VBF cuts
+
+        # lnJ case--------
         lnJ_addJet_pt = []
         lnJ_addJet_eta = []
         lnJ_addJet_phi = []
         lnJ_addJet_mass = []
         lnJ_addJet_jid = []
 
-	nlnJ_addJet = 0
-	if IsFatSig or IsFatSB or IsFatTop:
-	  for jdx in range(CleanJetNotFat_col._len):
-	    clj_i = CleanJetNotFat_col[jdx]['jetIdx']
-	    if ( CJet_col[clj_i]['pt'] < 30 ) or ( abs(CJet_col[clj_i]['eta'])>4.7 ): continue
-	    lnJ_addJet_pt.append(CJet_col[clj_i]['pt'])
-	    lnJ_addJet_eta.append(CJet_col[clj_i]['eta'])
-	    lnJ_addJet_phi.append(CJet_col[clj_i]['phi'])
-	    lnJ_addJet_mass.append(Jet_col[CJet_col[clj_i]['jetIdx']]['mass'])
-	    lnJ_addJet_jid.append(Jet_col[CJet_col[clj_i]['jetIdx']]['jetId'])
-	    nlnJ_addJet +=1
+        nlnJ_addJet = 0
+        if IsFatSig or IsFatSB or IsFatTop:
+            for jdx in range(CleanJetNotFat_col._len):
+                clj_i = CleanJetNotFat_col[jdx]['jetIdx']
+                if ( CJet_col[clj_i]['pt'] < 30 ) or ( abs(CJet_col[clj_i]['eta'])>4.7 ): continue
+                lnJ_addJet_pt.append(CJet_col[clj_i]['pt'])
+                lnJ_addJet_eta.append(CJet_col[clj_i]['eta'])
+                lnJ_addJet_phi.append(CJet_col[clj_i]['phi'])
+                lnJ_addJet_mass.append(Jet_col[CJet_col[clj_i]['jetIdx']]['mass'])
+                lnJ_addJet_jid.append(Jet_col[CJet_col[clj_i]['jetIdx']]['jetId'])
+                nlnJ_addJet +=1
 
-	  if nlnJ_addJet > 1:
-	    for i in range(nlnJ_addJet):
-	      for j in range(nlnJ_addJet):
-	        dEta_tmp = abs(lnJ_addJet_eta[i] - lnJ_addJet_eta[j])
-		mass_tmp = self.InvMassCalc(lnJ_addJet_pt[i],lnJ_addJet_eta[i],lnJ_addJet_phi[i],lnJ_addJet_mass[i],
-		  lnJ_addJet_pt[j],lnJ_addJet_eta[j],lnJ_addJet_phi[j],lnJ_addJet_mass[j])
-		if dEta_tmp > 3.5:
-		  if mass_tmp > vbfFat_jj_mass:
-		    vbfFat_jj_dEta = dEta_tmp
-		    vbfFat_jj_mass = mass_tmp
-	    if vbfFat_jj_mass > 500:
-	      IsVbfFat = True
+            if nlnJ_addJet > 1:
+                for i in range(nlnJ_addJet):
+                    for j in range(nlnJ_addJet):
+                        dEta_tmp = abs(lnJ_addJet_eta[i] - lnJ_addJet_eta[j])
+                        mass_tmp = self.InvMassCalc(lnJ_addJet_pt[i],lnJ_addJet_eta[i],
+                                                    lnJ_addJet_phi[i],lnJ_addJet_mass[i],
+                                                    lnJ_addJet_pt[j],lnJ_addJet_eta[j],
+                                                    lnJ_addJet_phi[j],lnJ_addJet_mass[j]
+                                                    )
+                        if dEta_tmp > 3.5:
+                            if mass_tmp > vbfFat_jj_mass:
+                                vbfFat_jj_dEta = dEta_tmp
+                                vbfFat_jj_mass = mass_tmp
+                if vbfFat_jj_mass > 500:
+                    IsVbfFat = True
 
-	# lnjj case ---------
+        # lnjj case ---------
         lnjj_addJet_pt = []
         lnjj_addJet_eta = []
         lnjj_addJet_phi = []
         lnjj_addJet_mass = []
         lnjj_addJet_jid = []
-	nlnjj_addJet = 0
-	if IsJjSig or IsJjSB or IsJjTop:
-	  for ci in range(CJet_col._len):
-	    # check if it is used
-	    if ci == Wjj_ClJet0_idx : continue
-	    if ci == Wjj_ClJet1_idx : continue
-	    if ( CJet_col[ci]['pt'] < 30 ) or ( abs(CJet_col[ci]['eta'])>4.7 ): continue
-	    lnjj_addJet_pt.append  (CJet_col[ci]['pt'])
-	    lnjj_addJet_eta.append (CJet_col[ci]['eta'])
-	    lnjj_addJet_phi.append (CJet_col[ci]['phi'])
-	    lnjj_addJet_mass.append(Jet_col[CJet_col[ci]['jetIdx']]['mass'])
-	    lnjj_addJet_jid.append (Jet_col[CJet_col[ci]['jetIdx']]['jetId'])
-	    nlnjj_addJet +=1
+        nlnjj_addJet = 0
+        if IsJjSig or IsJjSB or IsJjTop:
+            for ci in range(CJet_col._len):
+                # check if it is used
+                if ci == Wjj_ClJet0_idx : continue
+                if ci == Wjj_ClJet1_idx : continue
+                if ( CJet_col[ci]['pt'] < 30 ) or ( abs(CJet_col[ci]['eta'])>4.7 ): continue
+                lnjj_addJet_pt.append  (CJet_col[ci]['pt'])
+                lnjj_addJet_eta.append (CJet_col[ci]['eta'])
+                lnjj_addJet_phi.append (CJet_col[ci]['phi'])
+                lnjj_addJet_mass.append(Jet_col[CJet_col[ci]['jetIdx']]['mass'])
+                lnjj_addJet_jid.append (Jet_col[CJet_col[ci]['jetIdx']]['jetId'])
+                nlnjj_addJet +=1
 
-	  if nlnjj_addJet > 1:
-	    for i in range(nlnjj_addJet):
-	      for j in range(nlnjj_addJet):
-	        dEta_tmp = abs(lnjj_addJet_eta[i] - lnjj_addJet_eta[j])
-		mass_tmp = self.InvMassCalc(lnjj_addJet_pt[i],lnjj_addJet_eta[i],lnjj_addJet_phi[i],lnjj_addJet_mass[i],
-		                       lnjj_addJet_pt[j],lnjj_addJet_eta[j],lnjj_addJet_phi[j],lnjj_addJet_mass[j])
-		if dEta_tmp > 3.5:
-		  if mass_tmp > vbfjj_jj_mass:
-		    vbfjj_jj_dEta = dEta_tmp
-		    vbfjj_jj_mass = mass_tmp
-	    if vbfjj_jj_mass > 500:
-	      IsVbfjj = True
+            if nlnjj_addJet > 1:
+                for i in range(nlnjj_addJet):
+                    for j in range(nlnjj_addJet):
+                        dEta_tmp = abs(lnjj_addJet_eta[i] - lnjj_addJet_eta[j])
+                        mass_tmp = self.InvMassCalc(lnjj_addJet_pt[i],lnjj_addJet_eta[i],
+                                                    lnjj_addJet_phi[i],lnjj_addJet_mass[i],
+                                                    lnjj_addJet_pt[j],lnjj_addJet_eta[j],
+                                                    lnjj_addJet_phi[j],lnjj_addJet_mass[j])
+                        if dEta_tmp > 3.5:
+                            if mass_tmp > vbfjj_jj_mass:
+                                vbfjj_jj_dEta = dEta_tmp
+                                vbfjj_jj_mass = mass_tmp
+            if vbfjj_jj_mass > 500:
+                IsVbfjj = True
 
         EventVar['IsVbfFat'] = IsVbfFat
         EventVar['IsVbfjj'] = IsVbfjj
-        
 
 
-	if IsFatSig==False and IsFatSB==False and IsFatTop==False and IsJjSig==False and IsJjSB==False and IsJjTop==False:
-	  return False
-        
+
+        if IsFatSig==False and IsFatSB==False and IsFatTop==False and IsJjSig==False and IsJjSB==False and IsJjTop==False:
+            return False
+
 
 
         self.out.fillBranch( 'Flavlnjj' , Flavlnjj)
@@ -466,7 +470,7 @@ class HMlnjjVarsClass(Module):
         ##--complex number case
         if metPz_2_pow2 < 0:
             metPz = metPz_1
-        ##--real solution    
+        ##--real solution
         else:
             sol1 = metPz_1 + math.sqrt(metPz_2_pow2)
             sol2 = metPz_1 - math.sqrt(metPz_2_pow2)
@@ -476,7 +480,6 @@ class HMlnjjVarsClass(Module):
                 metPz = sol2
 
         return metPz
- 
-# define modules using the syntax 'name = lambda : constructor' to avoid having them loaded when not needed                    
-HMlnjjVars = lambda : HMlnjjVarsClass()
 
+# define modules using the syntax 'name = lambda : constructor' to avoid having them loaded when not needed
+HMlnjjVars = lambda : HMlnjjVarsClass()

--- a/NanoGardener/python/modules/HMlnjjVars.py
+++ b/NanoGardener/python/modules/HMlnjjVars.py
@@ -12,11 +12,11 @@ Wmass=80.4
 
 class HMlnjjVarsClass(Module):
     def __init__(self,year):
-    self.HlnFat_4v  = ROOT.TLorentzVector()
-    self.Hlnjj_4v   = ROOT.TLorentzVector()
-    self.Wlep_4v   = ROOT.TLorentzVector()
-    self.Wfat_4v   = ROOT.TLorentzVector()
-    self.Wjj_4v   = ROOT.TLorentzVector()
+        self.HlnFat_4v  = ROOT.TLorentzVector()
+        self.Hlnjj_4v   = ROOT.TLorentzVector()
+        self.Wlep_4v   = ROOT.TLorentzVector()
+        self.Wfat_4v   = ROOT.TLorentzVector()
+        self.Wjj_4v   = ROOT.TLorentzVector()
         print "@@Year->",year
         self.year=year
         # b-tag WP && tau21 (Wtag)
@@ -259,10 +259,10 @@ class HMlnjjVarsClass(Module):
         IsFat = all(Cat_Fat)
 
         Cat_AK4     = [IsWjj, met_pt > 30]
-        isJj = all(Cat_AK4)
+        IsJj = all(Cat_AK4)
 
 
-        EventVar['IsBoosted'] = isFat
+        EventVar['IsBoosted'] = IsFat
         EventVar['IsResolved'] = IsJj
         EventVar['IsTopTagged'] = Evt_btagged
 


### PR DESCRIPTION
The first commit fixes indentation problems I had in my editor (though it looked fine on github for some reason).
The second commit are the actual changes:
https://github.com/sebsiebert/LatinoAnalysis/commit/9d532b6cec0c5b7ca79c6f73288521efb74bdb3f?diff=unified

Removed the two lines requested by Pedro on Mattermost for monoH.

The module now only chooses between resolved and boosted category but doesn't split them further into SR / SB / topCR.

_Reverted_ ~Before, the top tagging of the event was done twice, once for boosted and once for resolved. Removed the second one, since the event should be considered tagged in any case (should loop be over CleanJetNotFat or all CleanJet?).
https://github.com/sebsiebert/LatinoAnalysis/blob/9d532b6cec0c5b7ca79c6f73288521efb74bdb3f/NanoGardener/python/modules/HMlnjjVars.py#L182-L190~

Definition of SR / CR now in cuts.py: For resolved category, hadronic W mass is Whad_mass. For boosted category the hadronic W candidates are in the CleanFatJetPassMBoosted collection.
