### PR TITLE
HMlnjjVars selection and 2HDMa semilep samples

### DIFF
--- a/NanoGardener/python/framework/PostProcMaker.py
+++ b/NanoGardener/python/framework/PostProcMaker.py
@@ -30,7 +30,7 @@ class PostProcMaker():
      self._cmsswBasedir = os.environ["CMSSW_BASE"]
 
      #self._aaaXrootd = 'root://cms-xrd-global.cern.ch//'
-     self._aaaXrootd = 'root://xrootd-cms.infn.it//'
+     self._aaaXrootd = 'root://xrootd-cms.infn.it/'
 
      self._haddnano  = 'PhysicsTools/NanoAODTools/scripts/haddnano.py'
 

--- a/NanoGardener/python/framework/Steps_cfg.py
+++ b/NanoGardener/python/framework/Steps_cfg.py
@@ -685,14 +685,7 @@ Steps = {
                   'isChain'    : True,
                   'do4MC'      : True,
 		  'do4Data'    : True,
-                  #'selection'  : '"(Lepton_pt[0] > 30 && (Alt$(Lepton_pt[1], 0) < 10))"',
-                  'selection'  : '"(Lepton_pt[0] > 30 && (Alt$(Lepton_pt[1], 0) < 10)) && (\
-                                    Lepton_isTightElectron_mvaFall17V1Iso_WP90[0] > 0.5 || \
-                                    Lepton_isTightElectron_mvaFall17V2Iso_WP90[0] > 0.5 || \
-                                    Lepton_isTightElectron_mvaFall17V1Iso_WP90_SS[0] > 0.5 || \
-                                    Lepton_isTightElectron_mvaFall17V2Iso_WP90_SS[0] > 0.5 || \
-                                    Lepton_isTightMuon_cut_Tight_HWWW[0] > 0.5 )"',
-                  #'selection'  : '"(Lepton_pt[0] > 30 && (Alt$(Lepton_pt[1], 0) < 10)) && (Lepton_isTightElectron_mvaFall17V1Iso_WP90[0]>0.5 || Lepton_isTightMuon_cut_Tight_HWWW[0]>0.5)"',
+                  'selection'  : '"(Lepton_pt[0] > 30 && (Alt$(Lepton_pt[1], 0) < 10))"',
                   'subTargets' : ['HMlnjjVars'],
 		  },
 

--- a/NanoGardener/python/framework/samples/fall17_102X_nAODv4.py
+++ b/NanoGardener/python/framework/samples/fall17_102X_nAODv4.py
@@ -665,3 +665,23 @@ Samples["ggZZ2e2m_ext1"] = {'nanoAOD':'/GluGluToContinToZZTo2e2mu_13TeV_MCFM701_
 Samples["ggZZ2e2m"] = {'nanoAOD':'/GluGluToContinToZZTo2e2mu_13TeV_MCFM701_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM'} 
 Samples["ggZZ4m_ext1"] = {'nanoAOD':'/GluGluToContinToZZTo4mu_13TeV_MCFM701_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6_ext1-v1/NANOAODSIM'}
 Samples["ggZZ4m"] = {'nanoAOD':'/GluGluToContinToZZTo4mu_13TeV_MCFM701_pythia8/RunIIFall17NanoAODv4-PU2017_12Apr2018_Nano14Dec2018_102X_mc2017_realistic_v6-v1/NANOAODSIM'}
+
+
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Senne 
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# monoH semilep 2HDMa
+Samples['2HDMa_SemiLep_MH3_200_MH4_150_pos'] = {'dasInst' : 'prod/phys03'  , 'nanoAOD' :'/monoHiggsMC_2HDMa_semiLep/fernanpe-EXO-2HDMa_Semilep_gg_sinp_0p35_tanb_1p0_mXd_10_MH3_200_MH4_150_MH2_200_MHC_200_pos_step4-f189fe9e1774a1be724b2f695108a46c/USER'}
+Samples['2HDMa_SemiLep_MH3_200_MH4_150_neg'] = {'dasInst' : 'prod/phys03'  , 'nanoAOD' :'/monoHiggsMC_2HDMa_semiLep/fernanpe-EXO-2HDMa_Semilep_gg_sinp_0p35_tanb_1p0_mXd_10_MH3_200_MH4_150_MH2_200_MHC_200_neg_step4-f189fe9e1774a1be724b2f695108a46c/USER'}
+Samples['2HDMa_SemiLep_MH3_300_MH4_150_pos'] = {'dasInst' : 'prod/phys03'  , 'nanoAOD' :'/monoHiggsMC_2HDMa_semiLep/fernanpe-EXO-2HDMa_Semilep_gg_sinp_0p35_tanb_1p0_mXd_10_MH3_300_MH4_150_MH2_300_MHC_300_pos_step4-f189fe9e1774a1be724b2f695108a46c/USER'}
+Samples['2HDMa_SemiLep_MH3_300_MH4_150_neg'] = {'dasInst' : 'prod/phys03'  , 'nanoAOD' :'/monoHiggsMC_2HDMa_semiLep/fernanpe-EXO-2HDMa_Semilep_gg_sinp_0p35_tanb_1p0_mXd_10_MH3_300_MH4_150_MH2_300_MHC_300_neg_step4-f189fe9e1774a1be724b2f695108a46c/USER'}
+Samples['2HDMa_SemiLep_MH3_400_MH4_150_pos'] = {'dasInst' : 'prod/phys03'  , 'nanoAOD' :'/monoHiggsMC_2HDMa_semiLep/fernanpe-EXO-2HDMa_Semilep_gg_sinp_0p35_tanb_1p0_mXd_10_MH3_400_MH4_150_MH2_400_MHC_400_pos_step4-f189fe9e1774a1be724b2f695108a46c/USER'}
+Samples['2HDMa_SemiLep_MH3_400_MH4_150_neg'] = {'dasInst' : 'prod/phys03'  , 'nanoAOD' :'/monoHiggsMC_2HDMa_semiLep/fernanpe-EXO-2HDMa_Semilep_gg_sinp_0p35_tanb_1p0_mXd_10_MH3_400_MH4_150_MH2_400_MHC_400_neg_step4-f189fe9e1774a1be724b2f695108a46c/USER'}
+Samples['2HDMa_SemiLep_MH3_500_MH4_150_pos'] = {'dasInst' : 'prod/phys03'  , 'nanoAOD' :'/monoHiggsMC_2HDMa_semiLep/fernanpe-EXO-2HDMa_Semilep_gg_sinp_0p35_tanb_1p0_mXd_10_MH3_500_MH4_150_MH2_500_MHC_500_pos_step4-f189fe9e1774a1be724b2f695108a46c/USER'}
+Samples['2HDMa_SemiLep_MH3_500_MH4_150_neg'] = {'dasInst' : 'prod/phys03'  , 'nanoAOD' :'/monoHiggsMC_2HDMa_semiLep/fernanpe-EXO-2HDMa_Semilep_gg_sinp_0p35_tanb_1p0_mXd_10_MH3_500_MH4_150_MH2_500_MHC_500_neg_step4-f189fe9e1774a1be724b2f695108a46c/USER'}
+Samples['2HDMa_SemiLep_MH3_600_MH4_150_pos'] = {'dasInst' : 'prod/phys03'  , 'nanoAOD' :'/monoHiggsMC_2HDMa_semiLep/fernanpe-EXO-2HDMa_Semilep_gg_sinp_0p35_tanb_1p0_mXd_10_MH3_600_MH4_150_MH2_600_MHC_600_pos_step4-f189fe9e1774a1be724b2f695108a46c/USER'}
+Samples['2HDMa_SemiLep_MH3_600_MH4_150_neg'] = {'dasInst' : 'prod/phys03'  , 'nanoAOD' :'/monoHiggsMC_2HDMa_semiLep/fernanpe-EXO-2HDMa_Semilep_gg_sinp_0p35_tanb_1p0_mXd_10_MH3_600_MH4_150_MH2_600_MHC_600_neg_step4-f189fe9e1774a1be724b2f695108a46c/USER'}
+Samples['2HDMa_SemiLep_MH3_1200_MH4_150_pos'] = {'dasInst' : 'prod/phys03'  , 'nanoAOD' :'/monoHiggsMC_2HDMa_semiLep/fernanpe-EXO-2HDMa_Semilep_gg_sinp_0p35_tanb_1p0_mXd_10_MH3_1200_MH4_150_MH2_1200_MHC_1200_pos_step4-f189fe9e1774a1be724b2f695108a46c/USER'}
+Samples['2HDMa_SemiLep_MH3_1200_MH4_150_neg'] = {'dasInst' : 'prod/phys03'  , 'nanoAOD' :'/monoHiggsMC_2HDMa_semiLep/fernanpe-EXO-2HDMa_Semilep_gg_sinp_0p35_tanb_1p0_mXd_10_MH3_1200_MH4_150_MH2_1200_MHC_1200_neg_step4-f189fe9e1774a1be724b2f695108a46c/USER'}

--- a/NanoGardener/python/framework/samples/samplesCrossSections2017.py
+++ b/NanoGardener/python/framework/samples/samplesCrossSections2017.py
@@ -914,6 +914,20 @@ samples['monoH_ZpBaryonic_MZp-10000_MChi-150'] .extend( ['xsec=0.000000000259886
 samples['monoH_ZpBaryonic_MZp-10000_MChi-10']  .extend( ['xsec=0.0000000002676616', 'kfact=1.000', 'ref=U'] ) 
 samples['monoH_ZpBaryonic_MZp-10000_MChi-1000'].extend( ['xsec=0.0000000001480138', 'kfact=1.000', 'ref=U'] ) 
 
+# monoH semilep 2HDMa
+samples['2HDMa_SemiLep_MH3_200_MH4_150_pos']  .extend( ['xsec=0.015210360197136',       'kfact=1.00',           'ref=N'] )
+samples['2HDMa_SemiLep_MH3_300_MH4_150_pos']  .extend( ['xsec=0.07493783178024',        'kfact=1.00',           'ref=N'] )
+samples['2HDMa_SemiLep_MH3_400_MH4_150_pos']  .extend( ['xsec=0.046148280579648',       'kfact=1.00',           'ref=N'] )
+samples['2HDMa_SemiLep_MH3_500_MH4_150_pos']  .extend( ['xsec=0.023652187335504',       'kfact=1.00',           'ref=N'] )
+samples['2HDMa_SemiLep_MH3_600_MH4_150_pos']  .extend( ['xsec=0.013931401855176',       'kfact=1.00',           'ref=N'] )
+samples['2HDMa_SemiLep_MH3_1200_MH4_150_pos'] .extend( ['xsec=0.0004962311561376',      'kfact=1.00',           'ref=N'] )
+
+samples['2HDMa_SemiLep_MH3_200_MH4_150_neg']  .extend( ['xsec=0.015210360197136',       'kfact=1.00',           'ref=N'] )
+samples['2HDMa_SemiLep_MH3_300_MH4_150_neg']  .extend( ['xsec=0.07493783178024',        'kfact=1.00',           'ref=N'] )
+samples['2HDMa_SemiLep_MH3_400_MH4_150_neg']  .extend( ['xsec=0.046148280579648',       'kfact=1.00',           'ref=N'] )
+samples['2HDMa_SemiLep_MH3_500_MH4_150_neg']  .extend( ['xsec=0.023652187335504',       'kfact=1.00',           'ref=N'] )
+samples['2HDMa_SemiLep_MH3_600_MH4_150_neg']  .extend( ['xsec=0.013931401855176',       'kfact=1.00',           'ref=N'] )
+samples['2HDMa_SemiLep_MH3_1200_MH4_150_neg'] .extend( ['xsec=0.0004962311561376',      'kfact=1.00',           'ref=N'] )
 
 
 # Stop T2tt FullSim


### PR DESCRIPTION
Simplification of HMlnjjLepSel:
flavour dependant pt cut => Lepton_pt[0] > 30, 
+ l1tightOR2017v5 that didn't come through

2HDMa semilep samples