### PR TITLE
add JER centralSF==1 case

### DIFF
--- a/NanoGardener/python/modules/FatJetMassScaler.py
+++ b/NanoGardener/python/modules/FatJetMassScaler.py
@@ -114,7 +114,13 @@ class FatJetMassScaler(Module):
             # get the base smearing given by resolution at the beginning
             # This is Gaus(0, res_MC) used for nominal smearing (relative to nominal (scaled) mass)
             raw_mass = mass / current_smear
-            sigma_MC_relative = (current_smear -1)  / ( sqrt(res_SF_central**2 -1))
+            sigma_MC_relative = 1
+
+            if res_SF_central!=1: ## if res_SF_central==1, denominator==0
+                sigma_MC_relative = (current_smear -1)  / ( sqrt(res_SF_central**2 -1))
+            else:
+                sigma_MC = self.rnd.Gaus(0, res_MC)
+                sigma_MC_relative= (sigma_MC/mass)
             
             if res_SF_var > 1:
                 smearfactor = 1 + sigma_MC_relative*sqrt(res_SF_var**2 - 1)


### PR DESCRIPTION
If JER centralSF==1, the line

   sigma_MC_relative = (current_smear -1)  / ( sqrt(res_SF_central**2 -1))

has zero denominator.(centralSF==1 case will not have additional smearing)

For that case, 'sigma_MC_relative' is fixed to be smeared  to

1+(sigma_MC/mass)*Gaus(0,res_MC)*sqrt(res_SF_var**2-1)


(Same form with central case)
