### PR TITLE
Check branch name in Runs Tree

### DIFF
--- a/NanoGardener/python/framework/PostProcMaker.py
+++ b/NanoGardener/python/framework/PostProcMaker.py
@@ -674,10 +674,12 @@ class PostProcMaker():
            f = ROOT.TFile.Open(self._aaaXrootd+iFile, "READ")
          Runs = f.Get("Runs")
          for iRun in Runs :
-           if DEBUG : print '---> genEventSumw = ', iRun.genEventSumw
-           genEventCount += iRun.genEventCount
-           genEventSumw  += iRun.genEventSumw
-           genEventSumw2 += iRun.genEventSumw2
+           trailer = ""
+           if hasattr(iRun, "genEventSumw_"): trailer = "_" 
+           if DEBUG : print '---> genEventSumw = ', getattr(iRun , "genEventSumw"+trailer)
+           genEventCount += getattr(iRun, "genEventCount"+trailer)
+           genEventSumw  += getattr(iRun, "genEventSumw"+trailer)
+           genEventSumw2 += getattr(iRun, "genEventSumw2"+trailer)
          f.Close()
        # get the X-section and baseW
        nEvt = genEventSumw

--- a/Tools/python/commonTools.py
+++ b/Tools/python/commonTools.py
@@ -297,7 +297,9 @@ def getEventSumw(directory,sample,prefix):
         f = ROOT.TFile.Open(iFile.replace('###',''), "READ")
         Runs=f.Get("Runs")
         for iRun in Runs:
-            genEventSumw  += iRun.genEventSumw
+            trailer = ""
+            if hasattr(iRun, "genEventSumw_"): trailer = "_" 
+            genEventSumw  += getattr(iRun, "genEventSumw"+trailer)
         f.Close()
     nEvt = genEventSumw
     return nEvt
@@ -370,9 +372,11 @@ def getBaseWnAOD(directory,iProd,Samples = [] , prodCfg='LatinoAnalysis/NanoGard
         f = ROOT.TFile.Open(iFile.replace('###',''),'READ')
         Runs = f.Get("Runs")
         for iRun in Runs :
-          genEventCount += iRun.genEventCount
-          genEventSumw  += iRun.genEventSumw
-          genEventSumw2 += iRun.genEventSumw2
+          trailer = ""
+          if hasattr(iRun, "genEventSumw_"): trailer = "_" 
+          genEventCount += getattr(iRun, "genEventCount"+trailer)
+          genEventSumw  += getattr(iRun, "genEventSumw" +trailer)
+          genEventSumw2 += getattr(iRun, "genEventSumw2"+trailer)
         f.Close()
     
     ### Get XS


### PR DESCRIPTION
In some nanoAODv6 samples branches in the Runs TTree have a trailing "_" in their names. 
This should make the code generic. 