### PR TITLE
Modules to add MELA EFT variables and gen information to ntuples

### DIFF
--- a/Gardener/python/variables/melaHiggsEFT.C
+++ b/Gardener/python/variables/melaHiggsEFT.C
@@ -1,55 +1,74 @@
 #include <math.h>
 #include <ZZMatrixElement/MELA/interface/Mela.h>
 
-std::vector<float> melaHiggsEFT(Mela *_mela, TVar::MatrixElement ME, TVar::Production Prod, bool IsGG, bool useConstant){
+std::vector<float> melaHiggsEFT(Mela *_mela, TVar::MatrixElement ME, TVar::Production Prod, bool IsGG, bool IsReco){
 
   std::vector<float> mes;
 
   bool Decay = 0;
+  double g2=1;
+  double g4=1;
+
   if(Prod==TVar::ZZGG || Prod==TVar::ZZINDEPENDENT)Decay = 1;
+
+  if(!IsReco){
+   if(Decay==1){
+    g2 = 1.133582;
+    g4 = 1.76132;
+   }else if(Prod==TVar::JJVBF){
+    g2 = 0.27196538;
+    g4 = 0.297979018705;
+   }else if(Prod==TVar::Had_ZH || Prod==TVar::Lep_ZH){
+    g2 = 0.112481;
+    g4 = 0.144057;
+   }else if(Prod==TVar::Had_WH || Prod==TVar::Lep_WH){
+    g2 = 0.0998956;
+    g4 = 0.1236136;
+   }
+  }
 
   float me_hsm = -999;
   _mela->setProcess(TVar::HSMHiggs, ME, Prod);
-  if(Decay)_mela->computeP(me_hsm, useConstant); 
-  else     _mela->computeProdP(me_hsm, useConstant); 
+  if(Decay)_mela->computeP(me_hsm, IsReco); 
+  else     _mela->computeProdP(me_hsm, IsReco); 
   mes.push_back(me_hsm);
 
   float me_hm = -999;
   _mela->setProcess(TVar::H0minus, ME, Prod);
-  if(Decay)_mela->computeP(me_hm, useConstant);
-  else     _mela->computeProdP(me_hm, useConstant);
+  if(Decay)_mela->computeP(me_hm, IsReco);
+  else     _mela->computeProdP(me_hm, IsReco);
   mes.push_back(me_hm);
 
   float me_hp = -999;
   _mela->setProcess(TVar::H0hplus, ME, Prod);
-  if(Decay)_mela->computeP(me_hp, useConstant);
-  else     _mela->computeProdP(me_hp, useConstant);
+  if(Decay)_mela->computeP(me_hp, IsReco);
+  else     _mela->computeProdP(me_hp, IsReco);
   mes.push_back(me_hp);
 
   float me_hl = -999;
   _mela->setProcess(TVar::H0_g1prime2, ME, Prod);
-  if(Decay)_mela->computeP(me_hl, useConstant);
-  else     _mela->computeProdP(me_hl, useConstant);
+  if(Decay)_mela->computeP(me_hl, IsReco);
+  else     _mela->computeProdP(me_hl, IsReco);
   mes.push_back(me_hl);
 
   float me_mixhm = -999;
   _mela->setProcess(TVar::SelfDefine_spin0, ME, Prod);
   _mela->selfDHzzcoupl[0][gHIGGS_VV_1][0] = 1.;
-  _mela->selfDHzzcoupl[0][gHIGGS_VV_4][0] = 1.;    
+  _mela->selfDHzzcoupl[0][gHIGGS_VV_4][0] = g4;    
   if(IsGG) _mela->selfDHggcoupl[0][gHIGGS_GG_2][0]=1;        
-  if(Decay)_mela->computeP(me_mixhm , useConstant);
-  else     _mela->computeProdP(me_mixhm , useConstant);
+  if(Decay)_mela->computeP(me_mixhm , IsReco);
+  else     _mela->computeProdP(me_mixhm , IsReco);
   mes.push_back(me_mixhm);
 
   float me_mixhp = -999;
   _mela->setProcess(TVar::SelfDefine_spin0, ME, Prod);
-  _mela->selfDHzzcoupl[0][gHIGGS_VV_1][0]=1.;
-  _mela->selfDHzzcoupl[0][gHIGGS_VV_2][0]=1.;   
+  _mela->selfDHzzcoupl[0][gHIGGS_VV_1][0]= 1.;
+  _mela->selfDHzzcoupl[0][gHIGGS_VV_2][0]= g2;   
   if(IsGG)  _mela->selfDHggcoupl[0][gHIGGS_GG_2][0]=1;                                                
-  if(Decay) _mela->computeP(me_mixhp, useConstant);
-  else      _mela->computeProdP(me_mixhp, useConstant);
+  if(Decay) _mela->computeP(me_mixhp, IsReco);
+  else      _mela->computeProdP(me_mixhp, IsReco);
   mes.push_back(me_mixhp);
- 
+
   return mes;
 
 }

--- a/Gardener/python/variables/melaHiggsEFT.C
+++ b/Gardener/python/variables/melaHiggsEFT.C
@@ -1,0 +1,60 @@
+#include <math.h>
+#include <ZZMatrixElement/MELA/interface/Mela.h>
+
+std::vector<float> melaHiggsEFT(Mela *_mela, TVar::MatrixElement ME, TVar::Production Prod, bool useConstant){
+
+  std::vector<float> mes;
+
+  bool IsGG = 0;
+  if(Prod==TVar::ZZGG || Prod==TVar::JJQCD)IsGG = 1;
+
+  bool Decay = 0;
+  if(Prod==TVar::ZZGG)Decay = 1;
+
+  float me_hsm = -999;
+  _mela->setProcess(TVar::HSMHiggs, ME, Prod);
+  if(Decay)_mela->computeP(me_hsm, useConstant); 
+  else     _mela->computeProdP(me_hsm, useConstant); 
+  mes.push_back(me_hsm);
+
+  float me_hm = -999;
+  _mela->setProcess(TVar::H0minus, ME, Prod);
+  if(Decay)_mela->computeP(me_hm, useConstant);
+  else     _mela->computeProdP(me_hm, useConstant);
+  mes.push_back(me_hm);
+
+  float me_hp = -999;
+  _mela->setProcess(TVar::H0hplus, ME, Prod);
+  if(Decay)_mela->computeP(me_hp, useConstant);
+  else     _mela->computeProdP(me_hp, useConstant);
+  mes.push_back(me_hp);
+
+  float me_hl = -999;
+  _mela->setProcess(TVar::H0_g1prime2, ME, Prod);
+  if(Decay)_mela->computeP(me_hl, useConstant);
+  else     _mela->computeProdP(me_hl, useConstant);
+  mes.push_back(me_hl);
+
+  float me_mixhm = -999;
+  _mela->setProcess(TVar::SelfDefine_spin0, ME, Prod);
+  _mela->selfDHzzcoupl[0][gHIGGS_VV_1][0] = 1.;
+  _mela->selfDHzzcoupl[0][gHIGGS_VV_4][0] = 1.;    
+  if(IsGG) _mela->selfDHggcoupl[0][gHIGGS_GG_2][0]=1;        
+  if(Decay)_mela->computeP(me_mixhm , useConstant);
+  else     _mela->computeProdP(me_mixhm , useConstant);
+  mes.push_back(me_mixhm);
+
+  float me_mixhp = -999;
+  _mela->setProcess(TVar::SelfDefine_spin0, ME, Prod);
+  _mela->selfDHzzcoupl[0][gHIGGS_VV_1][0]=1.;
+  _mela->selfDHzzcoupl[0][gHIGGS_VV_2][0]=1.;   
+  if(IsGG)  _mela->selfDHggcoupl[0][gHIGGS_GG_2][0]=1;                                                
+  if(Decay) _mela->computeP(me_mixhp, useConstant);
+  else      _mela->computeProdP(me_mixhp, useConstant);
+  mes.push_back(me_mixhp);
+ 
+  return mes;
+
+}
+
+

--- a/Gardener/python/variables/melaHiggsEFT.C
+++ b/Gardener/python/variables/melaHiggsEFT.C
@@ -1,15 +1,12 @@
 #include <math.h>
 #include <ZZMatrixElement/MELA/interface/Mela.h>
 
-std::vector<float> melaHiggsEFT(Mela *_mela, TVar::MatrixElement ME, TVar::Production Prod, bool useConstant){
+std::vector<float> melaHiggsEFT(Mela *_mela, TVar::MatrixElement ME, TVar::Production Prod, bool IsGG, bool useConstant){
 
   std::vector<float> mes;
 
-  bool IsGG = 0;
-  if(Prod==TVar::ZZGG || Prod==TVar::JJQCD)IsGG = 1;
-
   bool Decay = 0;
-  if(Prod==TVar::ZZGG)Decay = 1;
+  if(Prod==TVar::ZZGG || Prod==TVar::ZZINDEPENDENT)Decay = 1;
 
   float me_hsm = -999;
   _mela->setProcess(TVar::HSMHiggs, ME, Prod);

--- a/NanoGardener/python/framework/Steps_cfg.py
+++ b/NanoGardener/python/framework/Steps_cfg.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env python
 
 import os
@@ -1390,15 +1391,14 @@ Steps = {
                   'module'     : 'SusyGenVarsProducer()' ,
                },
 
-## EFT VBF H->WW->2l2nu
+## EFT JJH->WW->2l2nu
 
-    'VBFl2EFT' : {
+    'JJHl2EFT' : {
                   'isChain'    : True  ,
                   'do4MC'      : True  ,
                   'do4Data'    : True  ,
                   'subTargets' : ['JJHEFT','EFTGen'],
                   },
-
 
     'JJHEFT' : {
                    'isChain'    : False ,
@@ -1416,7 +1416,7 @@ Steps = {
                      'import'     : 'LatinoAnalysis.NanoGardener.modules.EFTReweighter' ,
                      'declare'    : 'EFTGen = lambda : EFTReweighter()',
                      'module'     : 'EFTGen()',
-                     'onlySample' : ['VBF_H0PM_ToWWTo2L2Nu','VBF_H0PH_ToWWTo2L2Nu','VBF_H0L1_ToWWTo2L2Nu','VBF_H0M_ToWWTo2L2Nu','VBF_H0PHf05_ToWWTo2L2Nu','VBF_H0Mf05_ToWWTo2L2Nu','VBF_H0L1f05_ToWWTo2L2Nu'],
+                     'onlySample' : ['H0PM_ToWWTo2L2Nu','H0PH_ToWWTo2L2Nu','H0L1_ToWWTo2L2Nu','H0M_ToWWTo2L2Nu','H0PHf05_ToWWTo2L2Nu','H0Mf05_ToWWTo2L2Nu','VBF_H0PM_ToWWTo2L2Nu','VBF_H0PH_ToWWTo2L2Nu','VBF_H0L1_ToWWTo2L2Nu','VBF_H0M_ToWWTo2L2Nu','VBF_H0PHf05_ToWWTo2L2Nu','VBF_H0Mf05_ToWWTo2L2Nu','WH_H0PM_ToWWTo2L2Nu','WH_H0PH_ToWWTo2L2Nu','WH_H0L1_ToWWTo2L2Nu','WH_H0M_ToWWTo2L2Nu','WH_H0PHf05_ToWWTo2L2Nu','WH_H0Mf05_ToWWTo2L2Nu','ZH_H0PM_ToWWTo2L2Nu','ZH_H0PH_ToWWTo2L2Nu','ZH_H0L1_ToWWTo2L2Nu','ZH_H0M_ToWWTo2L2Nu','ZH_H0PHf05_ToWWTo2L2Nu','ZH_H0Mf05_ToWWTo2L2Nu'],
                     },
 
     

--- a/NanoGardener/python/framework/Steps_cfg.py
+++ b/NanoGardener/python/framework/Steps_cfg.py
@@ -1397,7 +1397,6 @@ Steps = {
                   'do4MC'      : True  ,
                   'do4Data'    : True  ,
                   'subTargets' : ['JJHEFT','EFTGen'],
-                  'onlySample' : ['DYJetsToTT_MuEle_M-50','TTTo2L2Nu','WWTo2L2Nu','VBF_H0PM_ToWWTo2L2Nu','VBF_H0PH_ToWWTo2L2Nu','VBF_H0L1_ToWWTo2L2Nu','VBF_H0M_ToWWTo2L2Nu','VBF_H0PHf05_ToWWTo2L2Nu','VBF_H0Mf05_ToWWTo2L2Nu','VBF_H0L1f05_ToWWTo2L2Nu','GluGluHToWWTo2L2Nu_M125','GluGluHToTauTau_M125','VBFHToTauTau_M125'],
                   },
 
 
@@ -1408,7 +1407,6 @@ Steps = {
                    'import'     : 'LatinoAnalysis.NanoGardener.modules.JJH_EFTVars' ,
                    'declare'    : 'JJHEFT = lambda : JJH_EFTVars()',
                    'module'     : 'JJHEFT()',
-                   'onlySample' : ['DYJetsToTT_MuEle_M-50','TTTo2L2Nu','WWTo2L2Nu','VBF_H0PM_ToWWTo2L2Nu','VBF_H0PH_ToWWTo2L2Nu','VBF_H0L1_ToWWTo2L2Nu','VBF_H0M_ToWWTo2L2Nu','VBF_H0PHf05_ToWWTo2L2Nu','VBF_H0Mf05_ToWWTo2L2Nu','VBF_H0L1f05_ToWWTo2L2Nu','GluGluHToWWTo2L2Nu_M125','GluGluHToTauTau_M125','VBFHToTauTau_M125'],
                  },
 
     'EFTGen' : {

--- a/NanoGardener/python/framework/Steps_cfg.py
+++ b/NanoGardener/python/framework/Steps_cfg.py
@@ -1389,6 +1389,38 @@ Steps = {
                   'import'     : 'LatinoAnalysis.NanoGardener.modules.SusyGenVarsProducer' ,
                   'module'     : 'SusyGenVarsProducer()' ,
                },
+
+## EFT VBF H->WW->2l2nu
+
+    'VBFl2EFT' : {
+                  'isChain'    : True  ,
+                  'do4MC'      : True  ,
+                  'do4Data'    : True  ,
+                  'subTargets' : ['JJHEFT','EFTGen'],
+                  'onlySample' : ['DYJetsToTT_MuEle_M-50','TTTo2L2Nu','WWTo2L2Nu','VBF_H0PM_ToWWTo2L2Nu','VBF_H0PH_ToWWTo2L2Nu','VBF_H0L1_ToWWTo2L2Nu','VBF_H0M_ToWWTo2L2Nu','VBF_H0PHf05_ToWWTo2L2Nu','VBF_H0Mf05_ToWWTo2L2Nu','VBF_H0L1f05_ToWWTo2L2Nu','GluGluHToWWTo2L2Nu_M125','GluGluHToTauTau_M125','VBFHToTauTau_M125'],
+                  },
+
+
+    'JJHEFT' : {
+                   'isChain'    : False ,
+                   'do4MC'      : True ,
+                   'do4Data'    : True ,
+                   'import'     : 'LatinoAnalysis.NanoGardener.modules.JJH_EFTVars' ,
+                   'declare'    : 'JJHEFT = lambda : JJH_EFTVars()',
+                   'module'     : 'JJHEFT()',
+                   'onlySample' : ['DYJetsToTT_MuEle_M-50','TTTo2L2Nu','WWTo2L2Nu','VBF_H0PM_ToWWTo2L2Nu','VBF_H0PH_ToWWTo2L2Nu','VBF_H0L1_ToWWTo2L2Nu','VBF_H0M_ToWWTo2L2Nu','VBF_H0PHf05_ToWWTo2L2Nu','VBF_H0Mf05_ToWWTo2L2Nu','VBF_H0L1f05_ToWWTo2L2Nu','GluGluHToWWTo2L2Nu_M125','GluGluHToTauTau_M125','VBFHToTauTau_M125'],
+                 },
+
+    'EFTGen' : {
+                     'isChain'    : False ,
+                     'do4MC'      : True ,
+                     'do4Data'    : False ,
+                     'import'     : 'LatinoAnalysis.NanoGardener.modules.EFTReweighter' ,
+                     'declare'    : 'EFTGen = lambda : EFTReweighter()',
+                     'module'     : 'EFTGen()',
+                     'onlySample' : ['VBF_H0PM_ToWWTo2L2Nu','VBF_H0PH_ToWWTo2L2Nu','VBF_H0L1_ToWWTo2L2Nu','VBF_H0M_ToWWTo2L2Nu','VBF_H0PHf05_ToWWTo2L2Nu','VBF_H0Mf05_ToWWTo2L2Nu','VBF_H0L1f05_ToWWTo2L2Nu'],
+                    },
+
     
     ##--High Mass SemiLeptonic channel
   'wlepMaker' : {

--- a/NanoGardener/python/modules/EFTReweighter.py
+++ b/NanoGardener/python/modules/EFTReweighter.py
@@ -1,0 +1,239 @@
+
+import ROOT
+import math 
+import ctypes
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+
+from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection 
+from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
+from PhysicsTools.NanoAODTools.postprocessing.modules.common.collectionMerger import collectionMerger
+
+import os.path
+
+class EFTReweighter(Module):
+    def __init__(self):
+        
+        self.cmssw_base = os.getenv('CMSSW_BASE')
+        self.cmssw_arch = os.getenv('SCRAM_ARCH')
+
+        ROOT.gSystem.AddIncludePath("-I"+self.cmssw_base+"/interface/")
+        ROOT.gSystem.AddIncludePath("-I"+self.cmssw_base+"/src/")
+        ROOT.gSystem.Load("libZZMatrixElementMELA.so")
+        ROOT.gSystem.Load(self.cmssw_base+"/src/ZZMatrixElement/MELA/data/"+self.cmssw_arch+"/libmcfm_706.so")
+
+        try:
+            ROOT.gROOT.LoadMacro(self.cmssw_base+'/src/LatinoAnalysis/Gardener/python/variables/melaHiggsEFT.C+g')
+        except RuntimeError:
+            ROOT.gROOT.LoadMacro(self.cmssw_base+'/src/LatinoAnalysis/Gardener/python/variables/melaHiggsEFT.C++g')
+      
+        self.mela = ROOT.Mela(13, 125,  ROOT.TVar.SILENT) 
+
+    def beginJob(self):
+        pass
+
+    def endJob(self):
+        pass
+
+    def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+
+        filename = str(inputFile)[str(inputFile).find("nanoLatino"):str(inputFile).find(".root")+5]
+
+        if "_VBF_H0" in filename :
+          self.productionProcess = "VBF"
+          self.productionMela = ROOT.TVar.JJVBF
+        elif "_H0" in filename :
+          self.productionProcess = "GluGlu"
+          self.productionMela = ROOT.TVar.ZZGG 
+        else:
+          raise NameError(filename, "is an unrecognised simulation")
+
+        print("Running MELA EFT reweighter with " + self.productionProcess + " production configuration")
+
+        self.out = wrappedOutputTree
+        self.newbranches = [
+        'gen_me_hsm','gen_me_hm','gen_me_hp','gen_me_hl','gen_me_mixhm','gen_me_mixhp'  
+          ]
+        
+        for nameBranches in self.newbranches :
+          self.out.branch(nameBranches  ,  "F");
+
+    def endFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        pass
+
+    def analyze(self, event):
+        """process event, return True (go to next module) or False (fail, go to next event)"""
+
+        gen_me_hsm   = -999
+        gen_me_hm    = -999
+        gen_me_hp    = -999
+        gen_me_hl    = -999
+        gen_me_mixhm = -999
+        gen_me_mixhp = -999 
+
+        self.LHE = Collection(event,"LHEPart")
+        Gen = Collection(event,"GenPart")
+        LHEjetIdx = []
+
+        for idx,part in enumerate(self.LHE):
+          if abs(part.pdgId) in [1,2,3,4,5,21]:
+            LHEjetIdx.append(idx)
+
+        LHEjetIdx = self.pTorder(event, LHEjetIdx)
+
+        daughters=[]
+        daughterIDs=[]
+
+        FinalStateIdx = []
+        for gid,gen in enumerate(Gen):
+          if abs(gen.pdgId) >= 21: continue 
+          mid = event.GenPart_genPartIdxMother[gid]
+          if mid == -1: continue
+          if abs(event.GenPart_pdgId[mid]) != 24: continue 
+          gmid = event.GenPart_genPartIdxMother[mid]
+          if gmid == -1: continue
+          if abs(event.GenPart_pdgId[gmid]) != 25: continue 
+          if abs(gen.pdgId) in [11,12,13,14,15,16]: FinalStateIdx.append(gid) 
+
+        LHEFinalState = self.getLHE(event, FinalStateIdx) 
+
+        if len(LHEFinalState)!=4:
+          print "SOMETHING WENT WRONG!"
+          print "Event no.:",event.event
+          print LHEFinalState
+          print FinalStateIdx
+
+        for ipart in LHEFinalState:
+          l = ROOT.TLorentzVector()
+          l.SetPtEtaPhiM(LHEFinalState[ipart][0], LHEFinalState[ipart][1], LHEFinalState[ipart][2], 0.)
+          daughters.append(l)
+          daughterIDs.append(LHEFinalState[ipart][3])                            
+
+        mothers = ROOT.vector('TLorentzVector')()
+        motherIDs = ROOT.vector('int')()
+        incoming1=ROOT.TLorentzVector()
+        incoming1.SetPxPyPzE(0.,0., event.Generator_x1*6500, event.Generator_x1*6500)
+        incoming2=ROOT.TLorentzVector()
+        incoming2.SetPxPyPzE(0.,0.,-1*event.Generator_x2*6500, event.Generator_x2*6500)
+        mothers.push_back(incoming1)
+        mothers.push_back(incoming2)
+        genid1 = int(event.Generator_id1)
+        genid2 = int(event.Generator_id2)
+
+        partons   = ROOT.vector('TLorentzVector')()
+        partonIDs = ROOT.vector('int')()
+        parton_ids = []
+
+        for ijet in LHEjetIdx:
+          parton = ROOT.TLorentzVector()
+          parton.SetPtEtaPhiM(event.LHEPart_pt[ijet], event.LHEPart_eta[ijet], event.LHEPart_phi[ijet], 0.)
+          partons.push_back(parton)
+          partonIDs.push_back(int(event.LHEPart_pdgId[ijet]))
+          parton_ids.append(int(event.LHEPart_pdgId[ijet]))
+
+        if self.productionProcess == "VBF" and len(partons) !=2 :
+         print "Number of partons does not equal 2! Setup is not appropiate for this simulation"
+         print len(partons)
+
+        # Generator id seems to be wrong in few VBF events... -> Replace pdgId 21 by whatever is in LHE collection
+        if self.productionProcess == "VBF" and (genid1==21 or genid2==21) and (21 in parton_ids):
+          options = [o for o in parton_ids if o != 21] # Should usually contain 2 entries; There are _always_ 3 LHE jets because VBF samples are NLO
+          if genid1==21 and genid2!=21:
+            genid1 = options[0] + options[1] - genid2 # USUALLY Sum pdgIds incoming = Sum pdgIds outgoing (exception is 2.gen <-> 1.gen quark)
+            print "INFO: Replaced incoming particle ID1 to", genid1, "in event", event.event
+          elif genid1!=21 and genid2==21:
+            genid2 = options[0] + options[1] - genid1
+            print "INFO: Replaced incoming particle ID2 to", genid2, "in event", event.event
+          elif genid1==21 and genid2==21: # Assuming qq -> ZZ -> H
+            genid1 = options[0]
+            genid2 = options[1]
+            print "INFO: Replaced incoming particle ID1 to", genid1, "_AND_ ID2 to", genid2, " in event", event.event
+          print "incoming:", [genid1, genid2]
+          print "outgoing:", parton_ids
+
+        motherIDs.push_back(genid1)
+        motherIDs.push_back(genid2)        
+
+        daughter_coll = ROOT.SimpleParticleCollection_t() 
+        associated_coll = ROOT.SimpleParticleCollection_t()        
+        mother_coll = ROOT.SimpleParticleCollection_t()
+
+        for idx, dau in enumerate(daughters):
+         daughter_coll.push_back(ROOT.SimpleParticle_t(daughterIDs[idx], dau)) 
+        
+        for idx, par in enumerate(partons):
+         associated_coll.push_back(ROOT.SimpleParticle_t(partonIDs[idx], par))
+        
+        for idx, mot in enumerate(mothers):
+         mother_coll.push_back(ROOT.SimpleParticle_t(motherIDs[idx], mot))
+                                 
+        self.mela.setCandidateDecayMode(ROOT.TVar.CandidateDecay_WW)   
+        self.mela.setInputEvent(daughter_coll, associated_coll, mother_coll, 1)
+        self.mela.setCurrentCandidateFromIndex(0)
+        
+        ME = ROOT.melaHiggsEFT(self.mela, ROOT.TVar.JHUGen, self.productionMela, 0) 
+
+        gen_me_hsm   = ME[0]
+        gen_me_hm    = ME[1]
+        gen_me_hp    = ME[2]
+        gen_me_hl    = ME[3]
+        gen_me_mixhm = ME[4]
+        gen_me_mixhp = ME[5] 
+
+        self.mela.resetInputEvent()
+
+        self.out.fillBranch( 'gen_me_hsm',  gen_me_hsm )
+        self.out.fillBranch( 'gen_me_hm',   gen_me_hm )
+        self.out.fillBranch( 'gen_me_hp',   gen_me_hp )
+        self.out.fillBranch( 'gen_me_hl',   gen_me_hl )
+        self.out.fillBranch( 'gen_me_mixhm',  gen_me_mixhm )
+        self.out.fillBranch( 'gen_me_mixhp',  gen_me_mixhp )
+
+        return True   
+
+    def pTorder(self, event, oldlist):
+      order = []
+      for i in oldlist:
+        order.append(0)
+      for i,pone in enumerate(oldlist):
+        for j,ptwo in enumerate(oldlist):
+          if pone==ptwo: continue
+          if event.LHEPart_pt[pone] > event.LHEPart_pt[ptwo]: order[i] += 1
+          if (event.LHEPart_pt[pone] == event.LHEPart_pt[ptwo]) and (i<j):
+            order[j] += 1
+      newlist = [oldlist[i] for i in order]
+      return newlist
+
+    def getLHE(self, event, genlist): # Particles in LHE collection have higher precision -> Find LHE particles with closest match to GenParticles
+      LHElist = {}
+      for gid in genlist:
+        pt = event.GenPart_pt[gid]
+        eta = event.GenPart_eta[gid]
+        phi = event.GenPart_phi[gid]
+        pdgid = event.GenPart_pdgId[gid]
+        deltaR = 9999
+        LHEid = -1
+        for lid,lhe in enumerate(self.LHE):
+          if lhe.pdgId != pdgid: continue
+          dphi = phi-lhe.phi
+          if dphi > math.pi: dphi -= 2*math.pi
+          if dphi < -math.pi: dphi += 2*math.pi
+          deta = eta-lhe.eta
+          dR = math.sqrt((deta)*(deta)+(dphi)*(dphi))
+          if deltaR > dR:
+            deltaR = dR
+            LHEid = lid
+            LHEpt = lhe.pt
+            LHEeta = lhe.eta
+            LHEphi = lhe.phi
+            LHEpdg = lhe.pdgId
+        if LHEid==-1: # VERY rare, use placeholder key value
+          LHElist[pdgid+100*(len(LHElist)+1)]=[pt, eta, phi, pdgid]
+        elif deltaR > 0.2: # Use GenPart information if direction is too different
+          LHElist[LHEid]=[pt, eta, phi, pdgid]
+        else:
+          LHElist[LHEid]=[LHEpt, LHEeta, LHEphi, pdgid]
+        
+      return LHElist
+    
+
+      

--- a/NanoGardener/python/modules/JJH_EFTVars.py
+++ b/NanoGardener/python/modules/JJH_EFTVars.py
@@ -27,7 +27,6 @@ class JJH_EFTVars(Module):
             ROOT.gROOT.LoadMacro(self.cmssw_base+'/src/LatinoAnalysis/Gardener/python/variables/melaHiggsEFT.C++g')
       
         self.mela = ROOT.Mela(13, 125,  ROOT.TVar.SILENT) 
-        self.UseHMJetPair = False
 
     def beginJob(self):
         pass
@@ -38,9 +37,11 @@ class JJH_EFTVars(Module):
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree
         self.newbranches = [
-          'hm','hpt','jj_mass','jj_deta',
+          'hm','hpt',
           'me_vbf_hsm','me_vbf_hm','me_vbf_hp','me_vbf_hl','me_vbf_mixhm','me_vbf_mixhp',
-          'me_qcd_hsm','me_qcd_hm','me_qcd_hp','me_qcd_hl','me_qcd_mixhm','me_qcd_mixhp',
+          'me_wh_hsm','me_wh_hm','me_wh_hp','me_wh_hl','me_wh_mixhm','me_wh_mixhp',
+          'me_zh_hsm','me_zh_hm','me_zh_hp','me_zh_hl','me_zh_mixhm','me_zh_mixhp',
+          'me_qcd_hsm',
           ]
         
 
@@ -64,22 +65,25 @@ class JJH_EFTVars(Module):
 
         hm = -999
         hpt = -999
-        j1_pt = -999
-        j2_pt = -999
-        jj_mass = -999
-        jj_deta = -999
         me_vbf_hsm = -999 
         me_vbf_hm = -999 
         me_vbf_hp = -999 
         me_vbf_hl = -999 
         me_vbf_mixhm = -999 
         me_vbf_mixhp = -999
+        me_wh_hsm = -999 
+        me_wh_hm = -999 
+        me_wh_hp = -999 
+        me_wh_hl = -999 
+        me_wh_mixhm = -999 
+        me_wh_mixhp = -999
+        me_zh_hsm = -999 
+        me_zh_hm = -999 
+        me_zh_hp = -999 
+        me_zh_hl = -999 
+        me_zh_mixhm = -999 
+        me_zh_mixhp = -999
         me_qcd_hsm = -999 
-        me_qcd_hm = -999 
-        me_qcd_hp = -999 
-        me_qcd_hl = -999 
-        me_qcd_mixhm = -999 
-        me_qcd_mixhp = -999
             
         if nJet > 1 and nLepton > 1:
 
@@ -110,33 +114,12 @@ class JJH_EFTVars(Module):
          indx_j1 = 0
          indx_j2 = 1 
 
-         if nJet > 2 and self.UseHMJetPair :
-          max_mass = 0          
-          tJ1 = ROOT.TLorentzVector()  
-          tJ2 = ROOT.TLorentzVector()  
-          for i in range(nJet):
-           for j in range(nJet):
-            oi = Jet[i].jetIdx
-            oj = Jet[j].jetIdx
-            tJ1.SetPtEtaPhiM(Jet[i].pt, Jet[i].eta, Jet[i].phi, OrigJet[oi].mass)
-            tJ2.SetPtEtaPhiM(Jet[j].pt, Jet[j].eta, Jet[j].phi, OrigJet[oj].mass)
-            tMass = (tJ1 + tJ2).M()
-            if tMass > max_mass:
-             max_mass = tMass
-             indx_j1 = i
-             indx_j2 = j    
-
          J1 = ROOT.TLorentzVector()
          J2 = ROOT.TLorentzVector() 
          indx_oj1 = Jet[indx_j1].jetIdx
          indx_oj2 = Jet[indx_j2].jetIdx
          J1.SetPtEtaPhiM(Jet[indx_j1].pt, Jet[indx_j1].eta, Jet[indx_j1].phi, OrigJet[indx_oj1].mass)
          J2.SetPtEtaPhiM(Jet[indx_j2].pt, Jet[indx_j2].eta, Jet[indx_j2].phi, OrigJet[indx_oj2].mass)
- 
-         j1_pt = J1.Pt()
-         j2_pt = J2.Pt()
-         jj_mass = (J1 + J2).M()
-         jj_deta = abs(J1.Eta() - J2.Eta())
 
          daughter_coll = ROOT.SimpleParticleCollection_t() 
          associated_coll = ROOT.SimpleParticleCollection_t()
@@ -161,41 +144,49 @@ class JJH_EFTVars(Module):
          me_vbf_mixhm = ME_VBF[4]
          me_vbf_mixhp = ME_VBF[5] 
 
+         ME_WH = ROOT.melaHiggsEFT(self.mela, ROOT.TVar.JHUGen, ROOT.TVar.Had_WH, 0, 1)
+         me_wh_hsm   = ME_WH[0]
+         me_wh_hm    = ME_WH[1]
+         me_wh_hp    = ME_WH[2]
+         me_wh_hl    = ME_WH[3]
+         me_wh_mixhm = ME_WH[4]
+         me_wh_mixhp = ME_WH[5] 
+   
+         ME_ZH = ROOT.melaHiggsEFT(self.mela, ROOT.TVar.JHUGen, ROOT.TVar.Had_ZH, 0, 1)
+         me_zh_hsm   = ME_ZH[0]
+         me_zh_hm    = ME_ZH[1]
+         me_zh_hp    = ME_ZH[2]
+         me_zh_hl    = ME_ZH[3]
+         me_zh_mixhm = ME_ZH[4]
+         me_zh_mixhp = ME_ZH[5] 
+
          ME_QCD = ROOT.melaHiggsEFT(self.mela, ROOT.TVar.JHUGen, ROOT.TVar.JJQCD, 1, 1)
          me_qcd_hsm   = ME_QCD[0]
-         me_qcd_hm    = ME_QCD[1]
-         me_qcd_hp    = ME_QCD[2]
-         me_qcd_hl    = ME_QCD[3]
-         me_qcd_mixhm = ME_QCD[4]
-         me_qcd_mixhp = ME_QCD[5] 
-
-         ######### VH also possible ########
-         # ME_WH = ROOT.melaHiggsEFT(self.mela, ROOT.TVar.JHUGen, ROOT.TVar.Had_WH, 0, 1)
-         # ME_ZH = ROOT.melaHiggsEFT(self.mela, ROOT.TVar.JHUGen, ROOT.TVar.Had_ZH, 0, 1)
 
          self.mela.resetInputEvent()
-       
-      #  else:
-      #   return False         
-      #  if j1_pt < 30 or j2_pt < 30 :
-      #    return False 
+         
 
-        self.out.fillBranch( 'hm',         hm )
-        self.out.fillBranch( 'hpt',        hpt )
-        self.out.fillBranch( 'jj_mass',    jj_mass )
-        self.out.fillBranch( 'jj_deta',    jj_deta )
+        self.out.fillBranch( 'hm',          hm )
+        self.out.fillBranch( 'hpt',         hpt )
         self.out.fillBranch( 'me_vbf_hsm',  me_vbf_hsm )
         self.out.fillBranch( 'me_vbf_hm',   me_vbf_hm )
         self.out.fillBranch( 'me_vbf_hp',   me_vbf_hp ) 
         self.out.fillBranch( 'me_vbf_hl',   me_vbf_hl )
         self.out.fillBranch( 'me_vbf_mixhm',me_vbf_mixhm )
         self.out.fillBranch( 'me_vbf_mixhp',me_vbf_mixhp ) 
+        self.out.fillBranch( 'me_wh_hsm',   me_wh_hsm )
+        self.out.fillBranch( 'me_wh_hm',    me_wh_hm )
+        self.out.fillBranch( 'me_wh_hp',    me_wh_hp ) 
+        self.out.fillBranch( 'me_wh_hl',    me_wh_hl )
+        self.out.fillBranch( 'me_wh_mixhm', me_wh_mixhm )
+        self.out.fillBranch( 'me_wh_mixhp', me_wh_mixhp ) 
+        self.out.fillBranch( 'me_zh_hsm',   me_zh_hsm )
+        self.out.fillBranch( 'me_zh_hm',    me_zh_hm )
+        self.out.fillBranch( 'me_zh_hp',    me_zh_hp ) 
+        self.out.fillBranch( 'me_zh_hl',    me_zh_hl )
+        self.out.fillBranch( 'me_zh_mixhm', me_zh_mixhm )
+        self.out.fillBranch( 'me_zh_mixhp', me_zh_mixhp ) 
         self.out.fillBranch( 'me_qcd_hsm',  me_qcd_hsm )
-        self.out.fillBranch( 'me_qcd_hm',   me_qcd_hm )
-        self.out.fillBranch( 'me_qcd_hp',   me_qcd_hp ) 
-        self.out.fillBranch( 'me_qcd_hl',   me_qcd_hl )
-        self.out.fillBranch( 'me_qcd_mixhm',me_qcd_mixhm )
-        self.out.fillBranch( 'me_qcd_mixhp',me_qcd_mixhp )
 
         return True
 

--- a/NanoGardener/python/modules/JJH_EFTVars.py
+++ b/NanoGardener/python/modules/JJH_EFTVars.py
@@ -1,0 +1,191 @@
+
+import ROOT
+import math 
+import ctypes
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+
+from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection 
+from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
+from PhysicsTools.NanoAODTools.postprocessing.modules.common.collectionMerger import collectionMerger
+
+import os.path
+
+class JJH_EFTVars(Module):
+    def __init__(self):
+        
+        self.cmssw_base = os.getenv('CMSSW_BASE')
+        self.cmssw_arch = os.getenv('SCRAM_ARCH')
+
+        ROOT.gSystem.AddIncludePath("-I"+self.cmssw_base+"/interface/")
+        ROOT.gSystem.AddIncludePath("-I"+self.cmssw_base+"/src/")
+        ROOT.gSystem.Load("libZZMatrixElementMELA.so")
+        ROOT.gSystem.Load(self.cmssw_base+"/src/ZZMatrixElement/MELA/data/"+self.cmssw_arch+"/libmcfm_706.so")
+
+        try:
+            ROOT.gROOT.LoadMacro(self.cmssw_base+'/src/LatinoAnalysis/Gardener/python/variables/melaHiggsEFT.C+g')
+        except RuntimeError:
+            ROOT.gROOT.LoadMacro(self.cmssw_base+'/src/LatinoAnalysis/Gardener/python/variables/melaHiggsEFT.C++g')
+      
+        self.mela = ROOT.Mela(13, 125,  ROOT.TVar.SILENT) 
+        self.UseHMJetPair = False
+
+    def beginJob(self):
+        pass
+
+    def endJob(self):
+        pass
+
+    def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        self.out = wrappedOutputTree
+        self.newbranches = [
+          'hm','hpt','jj_mass','jj_deta',
+          'me_vbf_hsm','me_vbf_hm','me_vbf_hp','me_vbf_hl','me_vbf_mixhm','me_vbf_mixhp',
+          'me_qcd_hsm'
+          ]
+        
+
+        for nameBranches in self.newbranches :
+          self.out.branch(nameBranches  ,  "F");
+
+    def endFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        pass
+
+    def analyze(self, event):
+        """process event, return True (go to next module) or False (fail, go to next event)"""
+
+        Lepton = Collection(event, "Lepton")
+        nLepton = len(Lepton)
+
+        Jet   = Collection(event, "CleanJet")
+        nJet = len(Jet)
+ 
+        OrigJet = Collection(event, "Jet")
+        nOrigJet = len(OrigJet)
+
+        hm = -999
+        hpt = -999
+        j1_pt = -999
+        j2_pt = -999
+        jj_mass = -999
+        jj_deta = -999
+        me_vbf_hsm = -999 
+        me_vbf_hm = -999 
+        me_vbf_hp = -999 
+        me_vbf_hl = -999 
+        me_vbf_mixhm = -999 
+        me_vbf_mixhp = -999
+        me_qcd_hsm = -999  
+            
+        if nJet > 1 and nLepton > 1:
+
+         L1 = ROOT.TLorentzVector()
+         L2 = ROOT.TLorentzVector()
+         L1.SetPtEtaPhiM(Lepton[0].pt, Lepton[0].eta, Lepton[0].phi, 0)
+         L2.SetPtEtaPhiM(Lepton[1].pt, Lepton[1].eta, Lepton[1].phi, 0)
+
+         LL = ROOT.TLorentzVector()
+         LL = L1 + L2
+
+         MET_phi   = event.PuppiMET_phi
+         MET_pt    = event.PuppiMET_pt
+
+         NuNu = ROOT.TLorentzVector()
+         nunu_px = MET_pt*math.cos(MET_phi)
+         nunu_py = MET_pt*math.sin(MET_phi)
+         nunu_pz = LL.Pz()                                                                                                                  
+         nunu_m  = 30.0                                                                                                                                                                                      
+         nunu_e  = math.sqrt(nunu_px*nunu_px + nunu_py*nunu_py + nunu_pz*nunu_pz + nunu_m*nunu_m)
+         NuNu.SetPxPyPzE(nunu_px, nunu_py, nunu_pz, nunu_e)
+
+         Higgs = ROOT.TLorentzVector()
+         Higgs = LL + NuNu
+         hm  = Higgs.M()
+         hpt = Higgs.Pt()
+
+         indx_j1 = 0
+         indx_j2 = 1 
+
+         if nJet > 2 and self.UseHMJetPair :
+          max_mass = 0          
+          tJ1 = ROOT.TLorentzVector()  
+          tJ2 = ROOT.TLorentzVector()  
+          for i in range(nJet):
+           for j in range(nJet):
+            oi = Jet[i].jetIdx
+            oj = Jet[j].jetIdx
+            tJ1.SetPtEtaPhiM(Jet[i].pt, Jet[i].eta, Jet[i].phi, OrigJet[oi].mass)
+            tJ2.SetPtEtaPhiM(Jet[j].pt, Jet[j].eta, Jet[j].phi, OrigJet[oj].mass)
+            tMass = (tJ1 + tJ2).M()
+            if tMass > max_mass:
+             max_mass = tMass
+             indx_j1 = i
+             indx_j2 = j    
+
+         J1 = ROOT.TLorentzVector()
+         J2 = ROOT.TLorentzVector() 
+         indx_oj1 = Jet[indx_j1].jetIdx
+         indx_oj2 = Jet[indx_j2].jetIdx
+         J1.SetPtEtaPhiM(Jet[indx_j1].pt, Jet[indx_j1].eta, Jet[indx_j1].phi, OrigJet[indx_oj1].mass)
+         J2.SetPtEtaPhiM(Jet[indx_j2].pt, Jet[indx_j2].eta, Jet[indx_j2].phi, OrigJet[indx_oj2].mass)
+ 
+         j1_pt = J1.Pt()
+         j2_pt = J2.Pt()
+         jj_mass = (J1 + J2).M()
+         jj_deta = abs(J1.Eta() - J2.Eta())
+
+         daughter_coll = ROOT.SimpleParticleCollection_t() 
+         associated_coll = ROOT.SimpleParticleCollection_t()
+
+         daughter = ROOT.SimpleParticle_t(25, Higgs)
+         associated1 = ROOT.SimpleParticle_t(0, J1)
+         associated2 = ROOT.SimpleParticle_t(0, J2)
+
+         daughter_coll.push_back(daughter)                                                           
+         associated_coll.push_back(associated1)
+         associated_coll.push_back(associated2)
+
+         self.mela.setCandidateDecayMode(ROOT.TVar.CandidateDecay_Stable)   
+         self.mela.setInputEvent(daughter_coll, associated_coll, 0, 0)
+         self.mela.setCurrentCandidateFromIndex(0)
+        
+         ME_VBF = ROOT.melaHiggsEFT(self.mela, ROOT.TVar.JHUGen, ROOT.TVar.JJVBF, 1) 
+         me_vbf_hsm   = ME_VBF[0]
+         me_vbf_hm    = ME_VBF[1]
+         me_vbf_hp    = ME_VBF[2]
+         me_vbf_hl    = ME_VBF[3]
+         me_vbf_mixhm = ME_VBF[4]
+         me_vbf_mixhp = ME_VBF[5] 
+
+         ME_QCD = ROOT.melaHiggsEFT(self.mela, ROOT.TVar.JHUGen, ROOT.TVar.JJQCD, 1)
+         me_qcd_hsm   = ME_QCD[0]
+
+         ######### VH also possible ########
+         # ME_WH = ROOT.melaHiggsEFT(self.mela, ROOT.TVar.JHUGen, ROOT.TVar.Had_WH, 1)
+         # ME_ZH = ROOT.melaHiggsEFT(self.mela, ROOT.TVar.JHUGen, ROOT.TVar.Had_ZH, 1)
+
+         self.mela.resetInputEvent()
+       
+      #  else:
+      #   return False         
+      #  if j1_pt < 30 or j2_pt < 30 :
+      #    return False 
+
+        self.out.fillBranch( 'hm',         hm )
+        self.out.fillBranch( 'hpt',        hpt )
+        self.out.fillBranch( 'jj_mass',    jj_mass )
+        self.out.fillBranch( 'jj_deta',    jj_deta )
+        self.out.fillBranch( 'me_vbf_hsm',  me_vbf_hsm )
+        self.out.fillBranch( 'me_vbf_hm',   me_vbf_hm )
+        self.out.fillBranch( 'me_vbf_hp',   me_vbf_hp ) 
+        self.out.fillBranch( 'me_vbf_hl',   me_vbf_hl )
+        self.out.fillBranch( 'me_vbf_mixhm',me_vbf_mixhm )
+        self.out.fillBranch( 'me_vbf_mixhp',me_vbf_mixhp ) 
+        self.out.fillBranch( 'me_qcd_hsm',  me_qcd_hsm )
+
+        return True
+
+
+
+
+
+

--- a/NanoGardener/python/modules/JJH_EFTVars.py
+++ b/NanoGardener/python/modules/JJH_EFTVars.py
@@ -19,7 +19,7 @@ class JJH_EFTVars(Module):
         ROOT.gSystem.AddIncludePath("-I"+self.cmssw_base+"/interface/")
         ROOT.gSystem.AddIncludePath("-I"+self.cmssw_base+"/src/")
         ROOT.gSystem.Load("libZZMatrixElementMELA.so")
-        ROOT.gSystem.Load(self.cmssw_base+"/src/ZZMatrixElement/MELA/data/"+self.cmssw_arch+"/libmcfm_706.so")
+        ROOT.gSystem.Load(self.cmssw_base+"/src/ZZMatrixElement/MELA/data/"+self.cmssw_arch+"/libmcfm_707.so")
 
         try:
             ROOT.gROOT.LoadMacro(self.cmssw_base+'/src/LatinoAnalysis/Gardener/python/variables/melaHiggsEFT.C+g')
@@ -40,7 +40,7 @@ class JJH_EFTVars(Module):
         self.newbranches = [
           'hm','hpt','jj_mass','jj_deta',
           'me_vbf_hsm','me_vbf_hm','me_vbf_hp','me_vbf_hl','me_vbf_mixhm','me_vbf_mixhp',
-          'me_qcd_hsm'
+          'me_qcd_hsm','me_qcd_hm','me_qcd_hp','me_qcd_hl','me_qcd_mixhm','me_qcd_mixhp',
           ]
         
 
@@ -74,7 +74,12 @@ class JJH_EFTVars(Module):
         me_vbf_hl = -999 
         me_vbf_mixhm = -999 
         me_vbf_mixhp = -999
-        me_qcd_hsm = -999  
+        me_qcd_hsm = -999 
+        me_qcd_hm = -999 
+        me_qcd_hp = -999 
+        me_qcd_hl = -999 
+        me_qcd_mixhm = -999 
+        me_qcd_mixhp = -999
             
         if nJet > 1 and nLepton > 1:
 
@@ -148,7 +153,7 @@ class JJH_EFTVars(Module):
          self.mela.setInputEvent(daughter_coll, associated_coll, 0, 0)
          self.mela.setCurrentCandidateFromIndex(0)
         
-         ME_VBF = ROOT.melaHiggsEFT(self.mela, ROOT.TVar.JHUGen, ROOT.TVar.JJVBF, 1) 
+         ME_VBF = ROOT.melaHiggsEFT(self.mela, ROOT.TVar.JHUGen, ROOT.TVar.JJVBF, 0, 1) 
          me_vbf_hsm   = ME_VBF[0]
          me_vbf_hm    = ME_VBF[1]
          me_vbf_hp    = ME_VBF[2]
@@ -156,12 +161,17 @@ class JJH_EFTVars(Module):
          me_vbf_mixhm = ME_VBF[4]
          me_vbf_mixhp = ME_VBF[5] 
 
-         ME_QCD = ROOT.melaHiggsEFT(self.mela, ROOT.TVar.JHUGen, ROOT.TVar.JJQCD, 1)
+         ME_QCD = ROOT.melaHiggsEFT(self.mela, ROOT.TVar.JHUGen, ROOT.TVar.JJQCD, 1, 1)
          me_qcd_hsm   = ME_QCD[0]
+         me_qcd_hm    = ME_QCD[1]
+         me_qcd_hp    = ME_QCD[2]
+         me_qcd_hl    = ME_QCD[3]
+         me_qcd_mixhm = ME_QCD[4]
+         me_qcd_mixhp = ME_QCD[5] 
 
          ######### VH also possible ########
-         # ME_WH = ROOT.melaHiggsEFT(self.mela, ROOT.TVar.JHUGen, ROOT.TVar.Had_WH, 1)
-         # ME_ZH = ROOT.melaHiggsEFT(self.mela, ROOT.TVar.JHUGen, ROOT.TVar.Had_ZH, 1)
+         # ME_WH = ROOT.melaHiggsEFT(self.mela, ROOT.TVar.JHUGen, ROOT.TVar.Had_WH, 0, 1)
+         # ME_ZH = ROOT.melaHiggsEFT(self.mela, ROOT.TVar.JHUGen, ROOT.TVar.Had_ZH, 0, 1)
 
          self.mela.resetInputEvent()
        
@@ -181,6 +191,11 @@ class JJH_EFTVars(Module):
         self.out.fillBranch( 'me_vbf_mixhm',me_vbf_mixhm )
         self.out.fillBranch( 'me_vbf_mixhp',me_vbf_mixhp ) 
         self.out.fillBranch( 'me_qcd_hsm',  me_qcd_hsm )
+        self.out.fillBranch( 'me_qcd_hm',   me_qcd_hm )
+        self.out.fillBranch( 'me_qcd_hp',   me_qcd_hp ) 
+        self.out.fillBranch( 'me_qcd_hl',   me_qcd_hl )
+        self.out.fillBranch( 'me_qcd_mixhm',me_qcd_mixhm )
+        self.out.fillBranch( 'me_qcd_mixhp',me_qcd_mixhp )
 
         return True
 

--- a/NanoGardener/python/modules/JJH_EFTVars.py
+++ b/NanoGardener/python/modules/JJH_EFTVars.py
@@ -37,7 +37,7 @@ class JJH_EFTVars(Module):
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree
         self.newbranches = [
-          'hm','hpt',
+          'hm',
           'me_vbf_hsm','me_vbf_hm','me_vbf_hp','me_vbf_hl','me_vbf_mixhm','me_vbf_mixhp',
           'me_wh_hsm','me_wh_hm','me_wh_hp','me_wh_hl','me_wh_mixhm','me_wh_mixhp',
           'me_zh_hsm','me_zh_hm','me_zh_hp','me_zh_hl','me_zh_mixhm','me_zh_mixhp',
@@ -64,7 +64,6 @@ class JJH_EFTVars(Module):
         nOrigJet = len(OrigJet)
 
         hm = -999
-        hpt = -999
         me_vbf_hsm = -999 
         me_vbf_hm = -999 
         me_vbf_hp = -999 
@@ -109,7 +108,6 @@ class JJH_EFTVars(Module):
          Higgs = ROOT.TLorentzVector()
          Higgs = LL + NuNu
          hm  = Higgs.M()
-         hpt = Higgs.Pt()
 
          indx_j1 = 0
          indx_j2 = 1 
@@ -167,7 +165,6 @@ class JJH_EFTVars(Module):
          
 
         self.out.fillBranch( 'hm',          hm )
-        self.out.fillBranch( 'hpt',         hpt )
         self.out.fillBranch( 'me_vbf_hsm',  me_vbf_hsm )
         self.out.fillBranch( 'me_vbf_hm',   me_vbf_hm )
         self.out.fillBranch( 'me_vbf_hp',   me_vbf_hp ) 


### PR DESCRIPTION
There are two new modules. 

JJH_EFTVars.py calculates the EFT/AC related matrix elements for events with a H->WW->2l2nu candidate and 2 additional jets. Right now only the VBF matrix elements are added, but it is trivial to also include VH if required, this may be useful for Ashish if he decides to study this channel. 
These matrix elements can then be used to form kinematic discriminantes.  

EFTReweighter.py calculates the EFT/AC related matrix elements at generator level. It recognizes both the VBF and GluGlu EFT/AC signal samples and adds the relevant matrix elements to the ntuples. These can then be used to reweight the signal samples. 

Both modules make use of a macro melaHiggsEFT.C which returns a vector of relevant matrix elements. 

Also I added the step VBFl2EFT to Steps_cfg.py, which calls on the two modules described above. 
