### PR TITLE
Fix UEPS step when nin>nnom

### DIFF
--- a/NanoGardener/python/framework/PostProcMaker.py
+++ b/NanoGardener/python/framework/PostProcMaker.py
@@ -949,25 +949,26 @@ class PostProcMaker():
                if nin > nnom:
                  # If there are more nuisance variation files than the nominal files, merge the variations
                  # mkShapes cannot process the nuisance variations with more files than nominal
-                 nmerge = nin / nnom
-                 if nin % nnom != 0:
-                   nmerge += 1
 
-                 merging = self.buildHadd(iSample, FileInList, cutby='filecount', threshold=nmerge)
+                 NewFileInList = []
+                 for index,f in enumerate(FileInList):
+                   NewFileInList.append(re.sub("part.*root","part"+str(index)+".root",f))
+
+                 nmerge = nin - nnom
+                 for iFile in NewFileInList[:nnom-1]:
+                   tFile = self._targetDir + os.path.basename(iFile).replace(iSample,tSample)
+                   if not tFile in FileOutList or self._redo:
+                     os.system(self.mkStageOut(iFile,tFile,True))
 
                  tmpdir = tempfile.mkdtemp()
 
-                 for ttFile, sFiles in merging.iteritems():
-                   tFile = ttFile.replace(iSample, tSample)
-                   if tFile in FileOutList and not self._redo:
-                     continue
-                   
-                   tmpFile = tmpdir + '/' + os.path.basename(tFile)
-                   cmd = self._cmsswBasedir+'/src/'+self._haddnano+' '+tmpFile+' '
-                   cmd += ' '.join(self.getStageIn(sFile) for sFile in sFiles)
-                   os.system(cmd)
-                   os.system(self.mkStageOut(tmpFile, tFile, False))
-                   os.system('rm ' + tmpFile)
+                 tFile = self._targetDir+self._treeFilePrefix+tSample+'__part'+str(nnom-1)+'.root'.replace("//","/")
+                 tmpFile = tmpdir + '/' + os.path.basename(tFile)
+                 cmd = self._cmsswBasedir+'/src/'+self._haddnano+' '+tmpFile+' '
+                 cmd += ' '.join(self.getStageIn(sFile) for sFile in NewFileInList[-nmerge-1:])
+                 os.system(cmd)
+                 os.system(self.mkStageOut(tmpFile, tFile, False))
+                 os.system('rm ' + tmpFile)
 
                  os.system('rmdir ' + tmpdir)
 
@@ -984,7 +985,7 @@ class PostProcMaker():
                    pass
 
                  sourceName = (self._targetDir+self._treeFilePrefix+tSample+'__part0.root').replace('//','/')
-                 source = ROOT.TFile.Open(source)
+                 source = ROOT.TFile.Open(sourceName)
 
                  target = ROOT.TFile.Open(ftmp.name, 'recreate')
                  for key in source.GetListOfKeys():

--- a/NanoGardener/python/framework/Steps_cfg.py
+++ b/NanoGardener/python/framework/Steps_cfg.py
@@ -3293,8 +3293,8 @@ Steps = {
                   'do4MC'      : True  ,
                   'do4Data'    : False  ,
                   'onlySample' : [
-                                    'GluGluHToWWTo2L2NuPowheg_M125_CP5Up', 'VBFHToWWTo2L2NuPowheg_M125_CP5Up', 'WWTo2L2Nu_CP5Up',
-                                    'GluGluHToWWTo2L2NuPowheg_M125_CP5Down', 'VBFHToWWTo2L2NuPowheg_M125_CP5Down', 'WWTo2L2Nu_CP5Down',
+                                    'GluGluHToWWTo2L2NuPowheg_M125_CP5Up', 'VBFHToWWTo2L2NuPowheg_M125_CP5Up', 'VBFHToWWTo2L2Nu_M125_CP5Up', 'WWTo2L2Nu_CP5Up',
+                                    'GluGluHToWWTo2L2NuPowheg_M125_CP5Down', 'VBFHToWWTo2L2NuPowheg_M125_CP5Down', 'VBFHToWWTo2L2Nu_M125_CP5Down', 'WWTo2L2Nu_CP5Down',
                                     'GluGluHToWWTo2L2Nu_M125_CUETDown' , 'VBFHToWWTo2L2Nu_M125_CUETDown' , 'WWTo2L2Nu_CUETDown' ,
                                     'GluGluHToWWTo2L2Nu_M125_CUETUp'   , 'VBFHToWWTo2L2Nu_M125_CUETUp'   , 'WWTo2L2Nu_CUETUp'   ,
                                     'GluGluHToWWTo2L2NuHerwigPS_M125'  , 'VBFHToWWTo2L2NuHerwigPS_M125'  , 'WWTo2L2NuHerwigPS'  ,
@@ -3304,6 +3304,7 @@ Steps = {
                               'UEdo' : {
                                           'GluGluHToWWTo2L2NuPowheg_M125_CP5Down' : ['GluGluHToWWTo2L2NuPowheg_M125_PrivateNano' ,'GluGluHToWWTo2L2NuPowheg_M125'],
                                           'VBFHToWWTo2L2NuPowheg_M125_CP5Down'    : ['VBFHToWWTo2L2NuPowheg_M125_PrivateNano','VBFHToWWTo2L2NuPowheg_M125']    ,
+                                          'VBFHToWWTo2L2Nu_M125_CP5Down'    : ['VBFHToWWTo2L2Nu_M125']    ,
                                           'WWTo2L2Nu_CP5Down'               : ['WWTo2L2Nu_PrivateNano', 'WWTo2L2Nu'] ,
                                           'GluGluHToWWTo2L2Nu_M125_CUETDown' : ['GluGluHToWWTo2L2Nu_M125' ,'GluGluHToWWTo2L2NuPowheg_M125'],
                                           'VBFHToWWTo2L2Nu_M125_CUETDown'    : ['VBFHToWWTo2L2Nu_M125', 'VBFHToWWTo2L2NuPowheg_M125', 'VBFHToWWTo2L2Nu_alternative_M125']    ,
@@ -3312,6 +3313,7 @@ Steps = {
                               'UEup' : {
                                           'GluGluHToWWTo2L2NuPowheg_M125_CP5Up' : ['GluGluHToWWTo2L2NuPowheg_M125_PrivateNano' ,'GluGluHToWWTo2L2NuPowheg_M125'],
                                           'VBFHToWWTo2L2NuPowheg_M125_CP5Up'    : ['VBFHToWWTo2L2NuPowheg_M125_PrivateNano','VBFHToWWTo2L2NuPowheg_M125']    ,
+                                          'VBFHToWWTo2L2Nu_M125_CP5Up'    : ['VBFHToWWTo2L2Nu_M125']    ,
                                           'WWTo2L2Nu_CP5Up'               : ['WWTo2L2Nu_PrivateNano', 'WWTo2L2Nu'] ,
                                           'GluGluHToWWTo2L2Nu_M125_CUETUp'   : ['GluGluHToWWTo2L2Nu_M125' ,'GluGluHToWWTo2L2NuPowheg_M125'],
                                           'VBFHToWWTo2L2Nu_M125_CUETUp'      : ['VBFHToWWTo2L2Nu_M125', 'VBFHToWWTo2L2NuPowheg_M125', 'VBFHToWWTo2L2Nu_alternative_M125']    ,


### PR DESCRIPTION
This should fix the UEPS step when the number of files corresponding to the variations is greater than the number of nominal files. 
With this approach we end up with the same number of nominal and varied files.