### PR TITLE
fix integral for legend

### DIFF
--- a/ShapeAnalysis/python/PlotFactory.py
+++ b/ShapeAnalysis/python/PlotFactory.py
@@ -354,7 +354,7 @@ class PlotFactory:
                     sigForAdditionalRatioList[sampleName] = histos[sampleName]
                     sigForAdditionalDifferenceList[sampleName] = histos[sampleName]
                 else :
-                  nexpected += histos[sampleName].Integral(-1,-1)
+                  nexpected += histos[sampleName].Integral(1,histos[sampleName].GetNbinsX())   # it was (-1, -1) in the past, correct now
                   if variable['divideByBinWidth'] == 1:
                     histos[sampleName].Scale(1,"width")
 
@@ -907,18 +907,18 @@ class PlotFactory:
                         tlegend.AddEntry(histos[sampleName], plotdef['nameHR'], "F")
                       else :
                         if variable["divideByBinWidth"] == 1:
-                          nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX()+1,"width") 
+                          nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX(),"width") 
                         else:
-                          nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX()+1)
+                          nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX())
                         tlegend.AddEntry(histos[sampleName], plotdef['nameHR'] + " [" +  str(round(nevents,1)) + "]", "F")
                   else :
                     if self._showIntegralLegend == 0 :
                       tlegend.AddEntry(histos[sampleName], sampleName, "F")
                     else :
                       if variable["divideByBinWidth"] == 1:
-                        nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX()+1,"width")
+                        nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX(),"width")
                       else:
-                        nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX()+1)
+                        nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX())
                       tlegend.AddEntry(histos[sampleName], sampleName + " [" +  str(round(nevents,1)) + "]", "F")
                
               for sampleName in reversedSampleNames:
@@ -933,18 +933,18 @@ class PlotFactory:
                       tlegend.AddEntry(histos[sampleName], plotdef['nameHR'], "EPL")
                     else :
                       if variable["divideByBinWidth"] == 1:
-                        nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX()+1,"width")
+                        nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX(),"width")
                       else:
-                        nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX()+1)
+                        nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX())
                       tlegend.AddEntry(histos[sampleName], plotdef['nameHR'] + " [" +  str(round(nevents,1)) + "]", "EPL")
                   else :
                     if self._showIntegralLegend == 0 :
                       tlegend.AddEntry(histos[sampleName], sampleName, "EPL")
                     else :
                       if variable["divideByBinWidth"] == 1:
-                        nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX()+1,"width")
+                        nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX(),"width")
                       else:
-                        nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX()+1)
+                        nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX())
                       tlegend.AddEntry(histos[sampleName], sampleName + " [" +  str(round(nevents,1)) + "]", "EPL")
             
             else :
@@ -956,9 +956,9 @@ class PlotFactory:
                   tlegend.AddEntry(histos_grouped[sampleNameGroup], sampleConfiguration['nameHR'], "F")
                 else :
                   if variable["divideByBinWidth"] == 1:
-                    nevents = histos_grouped[sampleNameGroup].Integral(1,histos_grouped[sampleNameGroup].GetNbinsX()+1,"width")
+                    nevents = histos_grouped[sampleNameGroup].Integral(1,histos_grouped[sampleNameGroup].GetNbinsX(),"width")
                   else:
-                    nevents = histos_grouped[sampleNameGroup].Integral(1,histos_grouped[sampleNameGroup].GetNbinsX()+1)
+                    nevents = histos_grouped[sampleNameGroup].Integral(1,histos_grouped[sampleNameGroup].GetNbinsX())
                   tlegend.AddEntry(histos_grouped[sampleNameGroup], sampleConfiguration['nameHR'] + " [" +  str(round(nevents,1)) + "]" , "F")
                
               for sampleName in reversedSampleNames:
@@ -976,9 +976,9 @@ class PlotFactory:
                       tlegend.AddEntry(histos[sampleName], plotdef['nameHR'], "EPL")
                     else :
                       if variable["divideByBinWidth"] == 1:
-                        nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX()+1,"width")
+                        nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX(),"width")
                       else:
-                        nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX()+1)
+                        nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX())
                       print " nevents [", sampleName, "] = ", nevents
                       tlegend.AddEntry(histos[sampleName], plotdef['nameHR'] + " [" +  str(round(nevents,1)) + "]", "EPL")
                   else :
@@ -986,9 +986,9 @@ class PlotFactory:
                       tlegend.AddEntry(histos[sampleName], sampleName , "EPL")
                     else :
                       if variable["divideByBinWidth"] == 1:
-                        nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX()+1,"width")
+                        nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX(),"width")
                       else:
-                        nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX()+1)
+                        nevents = histos[sampleName].Integral(1,histos[sampleName].GetNbinsX())
                       print " nevents [", sampleName, "] = ", nevents
                       tlegend.AddEntry(histos[sampleName], sampleName + " [" +  str(round(nevents,1)) + "]", "EPL")
               


### PR DESCRIPTION
All integrals appearing in the legend now are set to show the "visible range only", namely only the bins that are visible in the plots.
This is consistent with mkdatacards too.