### PR TITLE
Update samplesCrossSections2018.py

### DIFF
--- a/NanoGardener/python/framework/samples/samplesCrossSections2018.py
+++ b/NanoGardener/python/framework/samples/samplesCrossSections2018.py
@@ -700,7 +700,7 @@ samples['GJets_HT40To100-ext1'] .extend( ['xsec=18740', 'kfact=1.000', 'ref=I'] 
 
 # VBS
 samples['WpWpJJ_EWK_QCD']   			.extend( ['xsec=0.05454',	'kfact=1.000',	'ref=I'] )
-samples['WpWpJJ_EWK']                           .extend( ['xsec=0.02526',       'kfact=1.000',  'ref=I'] )
+samples['WpWpJJ_EWK']                           .extend( ['xsec=0.01999',       'kfact=1.000',  'ref=I'] )
 samples['WpWpJJ_EWK_madgraph'] .extend( ['xsec=0.02526', 'kfact=1.000', 'ref=I'] )
 samples['WpWpJJ_QCD']                           .extend( ['xsec=0.02474',       'kfact=1.000',  'ref=I'] )
 samples['WpWpJJ_EWK_QCD_aQGC']                  .extend( ['xsec=0.1390',        'kfact=1.000',  'ref=I'] )


### PR DESCRIPTION
Correction to the cross section for sample:

`/WpWpJJ_EWK_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18NanoAODv6-Nano25Oct2019_102X_upgrade2018_realistic_v20-v1/NANOAODSIM`

the current value of 0.02526 is wrong, the correct one is 0.01999
the new value was checked with GenXsecAnalyzer
