### PR TITLE
mkplot normalized stack and removal of statistical uncertainty in mkdatacards

### DIFF
--- a/ShapeAnalysis/python/PlotFactory.py
+++ b/ShapeAnalysis/python/PlotFactory.py
@@ -99,8 +99,9 @@ class PlotFactory:
         list_thsBackground = {}
 
         list_thsSignal_grouped     = {}
-        list_thsSignalSup_grouped  = {}
         list_thsBackground_grouped = {}
+        list_thsSignal_grouped_normalized = {}
+        list_thsBackground_grouped_normalized = {}
 
         list_tcanvas               = {}
         list_tcanvasRatio          = {}
@@ -108,6 +109,7 @@ class PlotFactory:
         list_tcanvasDifference          = {}
         list_weight_X_tcanvasDifference = {}
         list_tcanvasSigVsBkg       = {}
+        list_tcanvasSigVsBkgTHstack = {}
 
         generalCounter = 0
 
@@ -147,6 +149,9 @@ class PlotFactory:
             weight_X_tcanvasDifference = ROOT.TCanvas( "weight_X_tcanvasDifference" + cutName + "_" + variableName, "weight_X_tcanvasDifference", 800, 800 )
             if self._plotNormalizedDistributions :
               tcanvasSigVsBkg    = ROOT.TCanvas( "ccSigVsBkg" + cutName + "_" + variableName,      "cc"     , 800, 600 )
+
+            if self._plotNormalizedDistributionsTHstack :
+              tcanvasSigVsBkgTHstack    = ROOT.TCanvas( "ccTHstackSigVsBkg" + cutName + "_" + variableName,      "cc"     , 800, 600 )
  
             list_tcanvas                 [generalCounter] = tcanvas
             list_tcanvasRatio            [generalCounter] = tcanvasRatio
@@ -155,6 +160,8 @@ class PlotFactory:
             list_weight_X_tcanvasDifference   [generalCounter] = weight_X_tcanvasDifference
             if self._plotNormalizedDistributions :
               list_tcanvasSigVsBkg         [generalCounter] = tcanvasSigVsBkg
+            if self._plotNormalizedDistributionsTHstack :
+              list_tcanvasSigVsBkgTHstack         [generalCounter] = tcanvasSigVsBkgTHstack
 
 
 
@@ -203,6 +210,14 @@ class PlotFactory:
             list_thsBackground         [generalCounter] = thsBackground
             list_thsSignal_grouped     [generalCounter] = thsSignal_grouped
             list_thsBackground_grouped [generalCounter] = thsBackground_grouped
+
+            # for special case of plotting normalized
+            thsSignal_grouped_normalized     = ROOT.THStack ("thsSignal_grouped_normalized_" + cutName + "_" + variableName,    "thsSignal_grouped_normalized_" + cutName + "_" + variableName)
+            thsBackground_grouped_normalized = ROOT.THStack ("thsBackground_grouped_normalized_" + cutName + "_" + variableName,"thsBackground_grouped_normalized_" + cutName + "_" + variableName)
+            list_thsSignal_grouped_normalized     [generalCounter] = thsSignal_grouped_normalized
+            list_thsBackground_grouped_normalized [generalCounter] = thsBackground_grouped_normalized
+
+
             generalCounter += 1
             
             #print '... after thstack ...'
@@ -2174,6 +2189,69 @@ class PlotFactory:
          
  
  
+            if self._plotNormalizedDistributionsTHstack :
+              # ~~~~~~~~~~~~~~~~~~~~
+              #
+              # Plot signal vs background normalized
+              # All the backgrounds or signals will be shown as stacked
+              # All contributions will be shown as well as in the normal stack distribution
+              # keeping though the integral of background and signal set to 1
+              #
+              
+              tcanvasSigVsBkgTHstack.cd()
+  
+              frameNormTHstack = ROOT.TH1F
+              frameNormTHstack = tcanvasSigVsBkgTHstack.DrawFrame(minXused, 0.0, maxXused, 1.0)
+  
+              frameNormTHstack.GetYaxis().SetRangeUser( 0, 1.5 )
+              # setup axis names
+              if 'xaxis' in variable.keys() : 
+                frameNormTHstack.GetXaxis().SetTitle(variable['xaxis'])
+              tcanvasSigVsBkgTHstack.RedrawAxis()
+  
+              maxY_normalized=0.0
+
+              h_sum_of_backgrounds = thsBackground_grouped.GetStack().Last() 
+              h_sum_of_signals = thsSignal_grouped.GetStack().Last() 
+              
+              normalization_factor_background = 1. / h_sum_of_backgrounds.Integral()
+              normalization_factor_signal = 1. / h_sum_of_signals.Integral()
+
+              if h_sum_of_backgrounds.Integral() > 0.:
+                maxY_normalized = h_sum_of_backgrounds.GetBinContent(h_sum_of_backgrounds.GetMaximumBin())/h_sum_of_backgrounds.Integral()
+              if h_sum_of_signals.Integral() > 0.:
+                temp_maxY_normalized = h_sum_of_signals.GetBinContent(h_sum_of_signals.GetMaximumBin())/h_sum_of_signals.Integral()
+                if (temp_maxY_normalized > maxY_normalized) :
+                  maxY_normalized = temp_maxY_normalized
+                
+              for hentry in thsBackground_grouped.GetHists():               
+                num_bins = hentry.GetNbinsX()
+                for ibin in range( num_bins ) :
+                  hentry.SetBinError(ibin+1, 0.000001)
+                hentry.SetFillStyle(0)
+                hentry.SetLineWidth(3)
+                hentry.Scale(normalization_factor_background)
+                thsBackground_grouped_normalized.Add(hentry)
+
+              for hentry in thsSignal_grouped.GetHists():               
+                num_bins = hentry.GetNbinsX()
+                for ibin in range( num_bins ) :
+                  hentry.SetBinError(ibin+1, 0.000001)
+                hentry.SetFillStyle(0)
+                hentry.SetLineWidth(3)
+                hentry.Scale(normalization_factor_signal)
+                thsSignal_grouped_normalized.Add(hentry)
+
+              thsSignal_grouped_normalized.Draw("hist same noclear")
+              thsBackground_grouped_normalized.Draw("hist same noclear")
+
+              frameNormTHstack.GetYaxis().SetRangeUser(0, 1.8*maxY_normalized)
+
+              tlegend.Draw()
+              self._saveCanvas(tcanvasSigVsBkgTHstack, self._outputDirPlots + "/" + 'ccTHstackSigVsBkg_' + cutName + "_" + variableName + self._FigNamePF, imageOnly=True)
+         
+
+
  
             
 

--- a/ShapeAnalysis/python/PlotFactory.py
+++ b/ShapeAnalysis/python/PlotFactory.py
@@ -2224,14 +2224,15 @@ class PlotFactory:
                 if (temp_maxY_normalized > maxY_normalized) :
                   maxY_normalized = temp_maxY_normalized
                 
-              for hentry in thsBackground_grouped.GetHists():               
-                num_bins = hentry.GetNbinsX()
-                for ibin in range( num_bins ) :
-                  hentry.SetBinError(ibin+1, 0.000001)
-                hentry.SetFillStyle(0)
-                hentry.SetLineWidth(3)
-                hentry.Scale(normalization_factor_background)
-                thsBackground_grouped_normalized.Add(hentry)
+              for hentry in thsBackground_grouped.GetHists():  
+                if hentry not in thsSignal_grouped.GetHists() :   # since signal is part of the "background" for plotting reason
+                  num_bins = hentry.GetNbinsX()
+                  for ibin in range( num_bins ) :
+                    hentry.SetBinError(ibin+1, 0.000001)
+                  hentry.SetFillStyle(0)
+                  hentry.SetLineWidth(3)
+                  hentry.Scale(normalization_factor_background)
+                  thsBackground_grouped_normalized.Add(hentry)
 
               for hentry in thsSignal_grouped.GetHists():               
                 num_bins = hentry.GetNbinsX()

--- a/ShapeAnalysis/scripts/mkDatacards.py
+++ b/ShapeAnalysis/scripts/mkDatacards.py
@@ -149,6 +149,14 @@ class DatacardFactory:
                     
                   yields[sampleName] = histo.Integral()
   
+                #
+                # Remove statistical uncertainty from the histogram
+                # This may be used to suppress the effect on "autoMCstat" of a specific
+                # sample, by means of putting its uncertainty to 0
+                #
+                if 'removeStatUnc' in structureFile[sampleName] :
+                  self._removeStatUncertainty (histo)
+                 
                 self._outFile.cd()
                 histo.Write()
 
@@ -586,6 +594,13 @@ class DatacardFactory:
             print shapeName, 'not found'
       
         return histo
+
+
+    # _____________________________________________________________________________
+    def _removeStatUncertainty(self, histo):
+        for iBin in range(0,histo.GetNbinsX()+2) :
+          histo.SetBinError(iBin,0.)
+
 
 
 if __name__ == '__main__':

--- a/ShapeAnalysis/scripts/mkDatacards.py
+++ b/ShapeAnalysis/scripts/mkDatacards.py
@@ -154,7 +154,7 @@ class DatacardFactory:
                 # This may be used to suppress the effect on "autoMCstat" of a specific
                 # sample, by means of putting its uncertainty to 0
                 #
-                if 'removeStatUnc' in structureFile[sampleName] :
+                if 'removeStatUnc' in structureFile[sampleName] and structureFile[sampleName]['removeStatUnc']:
                   self._removeStatUncertainty (histo)
                  
                 self._outFile.cd()

--- a/ShapeAnalysis/scripts/mkPlot.py
+++ b/ShapeAnalysis/scripts/mkPlot.py
@@ -56,7 +56,9 @@ if __name__ == '__main__':
 
     parser.add_option('--fileFormats'    , dest='fileFormats'    , help='Output plot file formats (comma-separated png, pdf, root, C, and/or eps). Default "png,root"', default='png,root')
 
-    parser.add_option('--plotNormalizedDistributions'  , dest='plotNormalizedDistributions'  , help='plot also normalized distributions for optimization purposes'         , default=None )
+    parser.add_option('--plotNormalizedDistributions'         , dest='plotNormalizedDistributions'         , help='plot also normalized distributions for optimization purposes'    ,    action='store_true'     , default=None )
+    parser.add_option('--plotNormalizedDistributionsTHstack'  , dest='plotNormalizedDistributionsTHstack'  , help='plot also normalized distributions for optimization purposes, with stacked sig and bkg'  ,    action='store_true'       , default=None )
+
     parser.add_option('--showIntegralLegend'           , dest='showIntegralLegend'           , help='show the integral, the yields, in the legend'                         , default=0,    type=float )
           
     parser.add_option('--showRelativeRatio'   , dest='showRelativeRatio'   , help='draw instead of data-expected, (data-expected) / expected' ,    action='store_true', default=False)
@@ -82,6 +84,7 @@ if __name__ == '__main__':
     print "                   inputFile =", opt.inputFile
     print "              outputDirPlots =", opt.outputDirPlots
     print " plotNormalizedDistributions =", opt.plotNormalizedDistributions
+    print " plotNormalizedDistributionsTHstack =", opt.plotNormalizedDistributionsTHstack
     print "          showIntegralLegend =", opt.showIntegralLegend
     print "                 scaleToPlot =", opt.scaleToPlot
     print "                     minLogC =", opt.minLogC
@@ -117,6 +120,7 @@ if __name__ == '__main__':
     factory._energy    = opt.energy
     factory._lumi      = opt.lumi
     factory._plotNormalizedDistributions = opt.plotNormalizedDistributions
+    factory._plotNormalizedDistributionsTHstack = opt.plotNormalizedDistributionsTHstack
     factory._showIntegralLegend = opt.showIntegralLegend
 
     if opt.onlyPlot is not None:


### PR DESCRIPTION
mkplot normalized stack : produce stack normalized plots for sig v bkg
- use case: you want to compare the shape of the full big vs full signal, but yet you want also to see the contributions from the backgrounds/signal, looking at their different composition. E.g. if a background has a super small contribution, you don't care too much
- how to use: "--plotNormalizedDistributionsTHstack" in mkPlot.py

statistical uncertainty in mkdatacards
- use case: if you want to remove some statistical uncertainty from the histogram, that will be later used by combine for the autoMCstat (a.k.a. bin by bin uncertainty). Possible use case is related to the combine model to be used later (EFT fits re-using the same samples)
- how to use: " 'removeStatUnc' : 1 " should be a field in the file "structure.py"
E.g.

structure['cHbox_int']  = {  
                            'isSignal' : 0, 
                            'isData' : 0 ,
                            'removeStatUnc' : 1      # remove statistical uncertainty on this sample
                            }



