### PR TITLE
filesUp/Down for batch

### DIFF
--- a/ShapeAnalysis/python/PlotFactory.py
+++ b/ShapeAnalysis/python/PlotFactory.py
@@ -902,7 +902,9 @@ class PlotFactory:
 
                 if plotdef['isData'] == 0 :
                   if 'nameHR' in plotdef.keys() :
-                    if plotdef['nameHR'] != '' :
+                    if plotdef['nameHR'] == '' :
+                      pass
+                    else:
                       if self._showIntegralLegend == 0 :
                         tlegend.AddEntry(histos[sampleName], plotdef['nameHR'], "F")
                       else :
@@ -951,8 +953,9 @@ class PlotFactory:
               for sampleNameGroup, sampleConfiguration in groupPlot.iteritems():
                 if 'samples' in variable and len(set(sampleConfiguration['samples']) & set(variable['samples'])) == 0:
                   continue
-                  
-                if self._showIntegralLegend == 0 :
+                if sampleConfiguration['nameHR']=='':
+                  pass
+                elif self._showIntegralLegend == 0 :
                   tlegend.AddEntry(histos_grouped[sampleNameGroup], sampleConfiguration['nameHR'], "F")
                 else :
                   if variable["divideByBinWidth"] == 1:
@@ -1019,6 +1022,9 @@ class PlotFactory:
               CMS_lumi.lumi_13TeV = legend['lumi']
             else:
               CMS_lumi.lumi_13TeV = 'L = %.1f fb^{-1}' % self._lumi
+            #BHO
+            if 'extraText' in legend.keys() :
+              CMS_lumi.extraText = legend['extraText']
         
             # Simple example of macro: plot with CMS name and lumi text
             #  (this script does not pretend to work in all configurations)
@@ -1069,7 +1075,10 @@ class PlotFactory:
             canvasPad1Name = 'pad1_' + cutName + "_" + variableName
             pad1 = ROOT.TPad(canvasPad1Name,canvasPad1Name, 0, 1-0.72, 1, 1)
             pad1.SetTopMargin(0.098)
-            pad1.SetBottomMargin(0.000) 
+            #BHO
+            #pad1.SetBottomMargin(0.000) 
+            pad1.SetBottomMargin(0.02) 
+            pad1.SetFrameFillStyle(4000)
             pad1.Draw()
             #pad1.cd().SetGrid()
             
@@ -1077,6 +1086,9 @@ class PlotFactory:
             #print " pad1 = ", pad1
             canvasFrameDistroName = 'frame_distro_' + cutName + "_" + variableName
             frameDistro = pad1.DrawFrame(minXused, 0.0, maxXused, 1.0, canvasFrameDistroName)
+            #BHO
+            frameDistro.GetXaxis().SetLabelOffset(1)
+            frameDistro.GetYaxis().SetLabelSize(0.04)
             #print " pad1 = ", pad1
             
             # style from https://ghm.web.cern.ch/ghm/plots/MacroExample/myMacro.py
@@ -1162,7 +1174,11 @@ class PlotFactory:
             tcanvasRatio.cd()
             canvasPad2Name = 'pad2_' + cutName + "_" + variableName
             pad2 = ROOT.TPad(canvasPad2Name,canvasPad2Name,0,0,1,1-0.72)
+            #BHO
             pad2.SetTopMargin(0.000)
+            #pad2.SetTopMargin(0.025)
+            #BHO
+            #pad2.SetFrameFillStyle(4000)
             pad2.SetBottomMargin(0.392)
             pad2.Draw()
             #pad2.cd().SetGrid()
@@ -2253,7 +2269,8 @@ class PlotFactory:
          yaxis.SetNdivisions ( 505)
          yaxis.SetTitleFont ( 42)
          yaxis.SetTitleOffset( .6)
-         yaxis.SetTitleSize ( 0.11)
+         #yaxis.SetTitleSize ( 0.11)
+         yaxis.SetTitleSize ( 0.1)
  
  
  

--- a/ShapeAnalysis/python/ShapeFactoryMulti.py
+++ b/ShapeAnalysis/python/ShapeFactoryMulti.py
@@ -305,7 +305,7 @@ class ShapeFactory:
                     ndrawer = nuisanceDrawers[nuisanceName][var] = self._connectInputs(sampleName, sub_files, '', skipMissingFiles=False)
                     # tree weights
                     treeweights_filesVar = {}
-                    treeweights_filesVar[var] = len(sub_files)*treeweights[0] if len(treeweights)>0 else []
+                    treeweights_filesVar[var] = len(sub_files)*[treeweights[0]] if len(treeweights)>0 else []
                     
                   else:
                     ndrawer = nuisanceDrawers[nuisanceName][var] = self._connectInputs(sampleName, nuisance['files' + var][sampleName], '', skipMissingFiles=False)

--- a/ShapeAnalysis/python/ShapeFactoryMulti.py
+++ b/ShapeAnalysis/python/ShapeFactoryMulti.py
@@ -277,6 +277,8 @@ class ShapeFactory:
               # Note that one has to use trees before skimming. The skimming can be applied on top is the additional tags 'skimListFolderUp' and 'skimListFolderDown'
               # are present. These tags hold the path to the directories holding the files holding the "prunerlist" event list
 
+              # tree-based weights for filesUp/Down
+              treeweights_filesVar = {}
               for var in variations:
                 if 'folder' + var in nuisance:
                   if 'unskimmedFriendTreeDir' in nuisance.keys():
@@ -303,8 +305,6 @@ class ShapeFactory:
                     filesPerJob = float(len(files))/float(nFileBlocks) # it could be non integer
                     sub_files = files[int(math.ceil(iFileBlock*filesPerJob)):int(math.ceil((iFileBlock+1)*filesPerJob))]
                     ndrawer = nuisanceDrawers[nuisanceName][var] = self._connectInputs(sampleName, sub_files, '', skipMissingFiles=False)
-                    # tree weights
-                    treeweights_filesVar = {}
                     treeweights_filesVar[var] = len(sub_files)*[treeweights[0]] if len(treeweights)>0 else []
                     
                   else:

--- a/ShapeAnalysis/python/ShapeFactoryMulti.py
+++ b/ShapeAnalysis/python/ShapeFactoryMulti.py
@@ -5,6 +5,7 @@ import copy
 import os.path
 import shutil
 import time
+import math
 import collections
 import tempfile
 import subprocess
@@ -293,7 +294,17 @@ class ShapeFactory:
     
                 elif 'files' + var in nuisance:
                   # TODO this feature is not fully working - I can't come up with a good way to assign variation files to batch jobs
-                  ndrawer = nuisanceDrawers[nuisanceName][var] = self._connectInputs(sampleName, nuisance['files' + var][sampleName], '', skipMissingFiles=False)
+                  #BHO sample['iFileBlock'], sample['nFileBlocks']
+                  if 'iFileBlock' in sample and 'nFileBlocks' in sample:
+                    iFileBlock, nFileBlocks = sample['iFileBlock'], sample['nFileBlocks']
+                    files = nuisance['files' + var][sampleName]
+                    if nFileBlocks > len(files):
+                      raise RuntimeError(" nFileBlocks > len(files) ")
+                    filesPerJob = float(len(files))/float(nFileBlocks) # it could be non integer
+                    sub_files = files[int(math.ceil(iFileBlock*filesPerJob)):int(math.ceil((iFileBlock+1)*filesPerJob))]
+                    ndrawer = nuisanceDrawers[nuisanceName][var] = self._connectInputs(sampleName, sub_files, '', skipMissingFiles=False)
+                  else:
+                    ndrawer = nuisanceDrawers[nuisanceName][var] = self._connectInputs(sampleName, nuisance['files' + var][sampleName], '', skipMissingFiles=False)
                   
                 ndrawers.append(ndrawer)
 

--- a/ShapeAnalysis/python/ShapeFactoryMulti.py
+++ b/ShapeAnalysis/python/ShapeFactoryMulti.py
@@ -303,6 +303,10 @@ class ShapeFactory:
                     filesPerJob = float(len(files))/float(nFileBlocks) # it could be non integer
                     sub_files = files[int(math.ceil(iFileBlock*filesPerJob)):int(math.ceil((iFileBlock+1)*filesPerJob))]
                     ndrawer = nuisanceDrawers[nuisanceName][var] = self._connectInputs(sampleName, sub_files, '', skipMissingFiles=False)
+                    # tree weights
+                    treeweights_filesVar = {}
+                    treeweights_filesVar[var] = len(sub_files)*treeweights[0] if len(treeweights)>0 else []
+                    
                   else:
                     ndrawer = nuisanceDrawers[nuisanceName][var] = self._connectInputs(sampleName, nuisance['files' + var][sampleName], '', skipMissingFiles=False)
                   
@@ -392,12 +396,19 @@ class ShapeFactory:
               else:
                 warnIfTreeWeight = False
 
-              for it, w in enumerate(treeweights):
-                if w is not None:
-                  ndrawer.setTreeReweight(it, False, w)
-                  if warnIfTreeWeight:
-                    print 'Nuisance', nuisanceName, 'tree filler for sample', sampleName, 'has different number of trees from the nominal filler. Tree-based reweighting may cause problems.'
+              if warnIfTreeWeight:
+                print 'Nuisance', nuisanceName, 'tree filler for sample', sampleName, 'has different number of trees from the nominal filler. Tree-based reweighting may cause problems.'
+                print 'Tree-based reweighting in nominal', treeweights 
+                print 'Tree-based reweighting in', tocheck, treeweights_filesVar[var]
+                for it, w in enumerate(treeweights_filesVar[var]):
+                  if w is not None:
+                    ndrawer.setTreeReweight(it, False, w)
                     warnIfTreeWeight = False
+              else:
+                for it, w in enumerate(treeweights):
+                  if w is not None:
+                    ndrawer.setTreeReweight(it, False, w)
+
 
           # Set up cuts
 

--- a/ShapeAnalysis/python/ShapeFactoryMulti.py
+++ b/ShapeAnalysis/python/ShapeFactoryMulti.py
@@ -327,10 +327,13 @@ class ShapeFactory:
             elif nkind.startswith('branch_custom'): ##[jhchoi]pick up sysbranch and sysfiles to replace given nominal
               print "--branch_custom--"
               for var in variations:
-                
-                friendAlias = nuisanceName + var
-                ndrawer = nuisanceDrawers[nuisanceName][var] = self._connectInputs(sampleName, sample['name'], inputDir, skipMissingFiles=False, friendsDir=(nuisance['folder' + var], friendAlias))
-                prefix = friendAlias+'.' ##read friendAlias as treename
+                if 'folder' + var in nuisance:
+                  friendAlias = nuisanceName + var
+                  ndrawer = nuisanceDrawers[nuisanceName][var] = self._connectInputs(sampleName, sample['name'], inputDir, skipMissingFiles=False, friendsDir=(nuisance['folder' + var], friendAlias))
+                  prefix = friendAlias+'.' ##read friendAlias as treename
+                else:
+                  ndrawer = nuisanceDrawers[nuisanceName][var] = self._connectInputs(sampleName, sample['name'], inputDir, skipMissingFiles=False)
+                  prefix = ''
                 for From,To in nuisance['BrFromTo'+var].items(): ##nuisance['BrFromToUp]  : a dictionary whose key =From , value ; To
                   ndrawer.replaceBranch(From,prefix+To)
                   print "From=",From,"To",To

--- a/ShapeAnalysis/scripts/mkShapesMulti.py
+++ b/ShapeAnalysis/scripts/mkShapesMulti.py
@@ -412,6 +412,12 @@ if __name__ == '__main__':
 
             clone = copy.deepcopy(sample)
             clone['name'] = sample['name'][filesPerJob * iFileBlock:filesPerJob * (iFileBlock + 1)]
+            #BHO 'for tree type nuisance filesUp/filesDown in batch'
+            clone['iFileBlock']  = iFileBlock
+            nFiles = len(sample['name'])
+            nFileBlocks = int(math.ceil(float(nFiles) / filesPerJob))
+            clone['nFileBlocks'] = nFileBlocks
+            #
             if 'weights' in sample:
               clone['weights'] = sample['weights'][filesPerJob * iFileBlock:filesPerJob * (iFileBlock + 1)]
 


### PR DESCRIPTION
filesUp/Down feature is not available in batch, so I add some lines for this.
First, 'iFileBlock' and 'nFileBlocks' keys are added in _mkShapesMulti.py_ script.
And then, up/down files are split for each job only if `nFileBlocks <= len(files)` is satisfied.

I tested this code for TTToSemiLeptonic/TTTo2L2Nu systematic samples.
```
nuisances['TuneCP5'] = {
    'name': 'CMS_TuneCP5',
    'kind': 'tree',
    'type': 'shape',
    'samples': dict((skey, ['1.','1.']) for skey in ['TTLJ+jj','TTLJ+bb','TTLJ+bj','TTLJ+cc','TTLL']),
    #name_TTLJ_TuneCP5Up = getSampleFiles(directory_syst,'TTToSemiLeptonic_TuneCP5Up',False,'nanoLatino_')
    #name_TTLJ_TuneCP5Down = getSampleFiles(directory_syst,'TTToSemiLeptonic_TuneCP5Down',False,'nanoLatino_')
    #name_TTLL_TuneCP5Up = getSampleFiles(directory_syst,'TTTo2L2Nu_TuneCP5Up',False,'nanoLatino_')
    #name_TTLL_TuneCP5Down = getSampleFiles(directory_syst,'TTTo2L2Nu_TuneCP5Down',False,'nanoLatino_')
    
    'filesUp'   : dict((skey, name_TTLJ_TuneCP5Up if 'TTLJ' in skey else name_TTLL_TuneCP5Up ) for skey in ['TTLJ+jj','TTLJ+bb','TTLJ+bj','TTLJ+cc','TTLL']), 
    'filesDown' : dict((skey, name_TTLJ_TuneCP5Down if 'TTLJ' in skey else name_TTLL_TuneCP5Down ) for skey in ['TTLJ+jj','TTLJ+bb','TTLJ+bj','TTLJ+cc','TTLL']),

}
```
<img width="311" alt="Screen Shot 2020-05-07 at 5 02 24 PM" src="https://user-images.githubusercontent.com/21118307/81269616-88988080-9084-11ea-82b6-054d4a3c3d1b.png">

<img width="649" alt="Screen Shot 2020-05-07 at 4 56 16 PM" src="https://user-images.githubusercontent.com/21118307/81269010-ad402880-9083-11ea-9111-dbd81d1b386b.png">

This nominal and up/down overlapped plot looks reasonable.