### PR TITLE
tmpfile per nuisance for tree type nuisances

### DIFF
--- a/ShapeAnalysis/python/ShapeFactoryMulti.py
+++ b/ShapeAnalysis/python/ShapeFactoryMulti.py
@@ -628,16 +628,20 @@ class ShapeFactory:
 
           print 'Start nominal histogram fill'
           drawer.execute(nevents, firstEvent)
+          tmpROOTFile.Close()
+          os.unlink(tmpfile.name)
 
           # tree-type nuisances
           for nuisanceName in nuisanceDrawers.keys():
+            tmpROOTFile = ROOT.TFile.Open(tmpfile.name, 'recreate')
+            tmpROOTFile.cd()
             ndrawers = nuisanceDrawers.pop(nuisanceName)
             for var, ndrawer in ndrawers.iteritems():
               print 'Start', nuisanceName + var, 'histogram fill'
               ndrawer.execute(nevents, firstEvent)
-
-          tmpROOTFile.Close()
-          os.unlink(tmpfile.name)
+            tmpROOTFile.Close()
+            os.unlink(tmpfile.name)
+          
 
           print 'Postfill'
 


### PR DESCRIPTION
To avoid too large tmp file , use only one tmp file per nuisance in tree-based type.

In old version, tmp file contains all trees of tree-based nuisances and then make shape one by one.

In this PR, a tmp file is made for a nuisance and removed after making shape of the nuisance.

I will save working space to 1/[the number of tree-based nuisances].
