### PR TITLE
Fix ordering logic

### DIFF
--- a/NanoGardener/python/modules/JERMaker.py
+++ b/NanoGardener/python/modules/JERMaker.py
@@ -142,13 +142,12 @@ class JERMaker(jetSmearer, object):
             jets_mass_JERUp  .append(jet_mass_JERUp)
             jets_mass_JERDown.append(jet_mass_JERDown) 
       
-        #Reorder
-        order = []
-        for idx1, pt1 in enumerate(jets_pt_nom):
-            pt_idx = 0
-            for idx2, pt2 in enumerate(jets_pt_nom):
-                if pt1 < pt2 or (pt1 == pt2 and idx1 > idx2): pt_idx += 1
-            order.append(pt_idx)
+        # Reorder
+        #
+        # e.g. if pt is         [ 26, 24, 27 ]
+        #      you get: order = [ 2, 0, 1]
+        #
+        order = sorted(range(len(jets_pt_nom)), key=jets_pt_nom.__getitem__, reverse=True)
 
         #Save to updated branches to jet collection
         for typ in self.collBr:

--- a/NanoGardener/python/modules/PtCorrApplier.py
+++ b/NanoGardener/python/modules/PtCorrApplier.py
@@ -161,12 +161,11 @@ class PtCorrApplier(Module):
                 MET[met]['new_phi'] = math.atan2(MET[met]['py'], MET[met]['px'])
 
         # Reorder
-        order = []
-        for idx1, pt1 in enumerate(new_pt):
-            pt_idx = 0
-            for idx2, pt2 in enumerate(new_pt):
-                if pt1 < pt2 or (pt1 == pt2 and idx1 > idx2): pt_idx += 1
-            order.append(pt_idx)
+        #
+        # e.g. if pt is         [ 26, 24, 27 ]
+        #      you get: order = [ 2, 0, 1]
+        #
+        order = sorted(range(len(new_pt)), key=new_pt.__getitem__, reverse=True)
  
         # Fill branches
         for typ in self.CollBr:

--- a/NanoGardener/python/modules/rochester_corrections.py
+++ b/NanoGardener/python/modules/rochester_corrections.py
@@ -184,12 +184,11 @@ class rochester_corr(Module):
             newpt_vec.append(newpt)
 
         # Reorder
-        order=[]
-        for idx1, pt1 in enumerate(newpt_vec):
-            pt_idx = 0
-            for idx2, pt2 in enumerate(newpt_vec):
-                if pt1 < pt2 or (pt1 == pt2 and idx1 > idx2): pt_idx += 1
-            order.append(pt_idx)
+        #
+        # e.g. if pt is         [ 26, 24, 27 ]
+        #      you get: order = [ 2, 0, 1]
+        #
+        order = sorted(range(len(newpt_vec)), key=newpt_vec.__getitem__, reverse=True)
 
         # Fill branches
         for typ in self.CollBr: 


### PR DESCRIPTION
Fix logic in ordering:

before


        # Reorder
        order=[]
        for idx1, pt1 in enumerate(newpt_vec):
            pt_idx = 0
            for idx2, pt2 in enumerate(newpt_vec):
                if pt1 < pt2 or (pt1 == pt2 and idx1 > idx2): pt_idx += 1
            order.append(pt_idx)



Now


        # Reorder
        #
        # e.g. if pt is         [ 26, 24, 27 ]
        #      you get: order = [ 2, 0, 1]
        #
        order = sorted(range(len(newpt_vec)), key=newpt_vec.__getitem__, reverse=True)



