### PR TITLE
2017 semileptonic signal samples (2HDMa and DarkHiggs)

### DIFF
--- a/NanoGardener/python/framework/samples/fall17_102X_nAODv7.py
+++ b/NanoGardener/python/framework/samples/fall17_102X_nAODv7.py
@@ -706,3 +706,36 @@ Samples['ttH_H0M_ToWWTo2L2Nu'] = {'nanoAOD' :'/ttHiggs0MToWWToLNu_2LOSfilter_M12
 Samples['ttH_H0Mf05_ToWWTo2L2Nu'] = {'nanoAOD' :'/ttHiggs0Mf05ph0ToWWToLNu_2LOSfilter_M125_13TeV_JHUGenV710_pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM'} ##!!!!
 ###Samples['ttH_H0L1f05_ToWWTo2L2Nu'] = {'nanoAOD' :''}
 
+
+#2HDMa semileptonic signal
+Samples['2HDMa_SemiLep_MH3_200_MH4_150_pos'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_2HDMa_semiLep/2HDMa_SemiLep_MH3_200_MH4_150_pos/201001_073333/0000/']}
+Samples['2HDMa_SemiLep_MH3_200_MH4_150_neg'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_2HDMa_semiLep/2HDMa_SemiLep_MH3_200_MH4_150_neg/201001_073344/0000/']}
+Samples['2HDMa_SemiLep_MH3_300_MH4_150_pos'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_2HDMa_semiLep/2HDMa_SemiLep_MH3_300_MH4_150_pos/201001_073355/0000/']}
+Samples['2HDMa_SemiLep_MH3_300_MH4_150_neg'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_2HDMa_semiLep/2HDMa_SemiLep_MH3_300_MH4_150_neg/201001_073406/0000/']}
+Samples['2HDMa_SemiLep_MH3_400_MH4_150_pos'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_2HDMa_semiLep/2HDMa_SemiLep_MH3_400_MH4_150_pos/201001_073416/0000/']}
+Samples['2HDMa_SemiLep_MH3_400_MH4_150_neg'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_2HDMa_semiLep/2HDMa_SemiLep_MH3_400_MH4_150_neg/201001_073428/0000/']}
+Samples['2HDMa_SemiLep_MH3_500_MH4_150_pos'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_2HDMa_semiLep/2HDMa_SemiLep_MH3_500_MH4_150_pos/201001_073438/0000/']}
+Samples['2HDMa_SemiLep_MH3_500_MH4_150_neg'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_2HDMa_semiLep/2HDMa_SemiLep_MH3_500_MH4_150_neg/201001_073449/0000/']}
+Samples['2HDMa_SemiLep_MH3_600_MH4_150_pos'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_2HDMa_semiLep/2HDMa_SemiLep_MH3_600_MH4_150_pos/201001_073500/0000/']}
+Samples['2HDMa_SemiLep_MH3_600_MH4_150_neg'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_2HDMa_semiLep/2HDMa_SemiLep_MH3_600_MH4_150_neg/201001_073511/0000/']}
+Samples['2HDMa_SemiLep_MH3_1200_MH4_150_pos'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_2HDMa_semiLep/2HDMa_SemiLep_MH3_1200_MH4_150_pos/201001_073522/0000/']}
+Samples['2HDMa_SemiLep_MH3_1200_MH4_150_neg'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_2HDMa_semiLep/2HDMa_SemiLep_MH3_1200_MH4_150_neg/201001_073533/0000/']}
+
+
+#DarkHiggs semileptonic signal
+Samples['DarkHiggs_SemiLep_MZP_195_pos'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_darkHiggs_semiLep/DarkHiggs_SemiLep_MZP_195_pos/201001_141124/0000/']}
+Samples['DarkHiggs_SemiLep_MZP_195_neg'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_darkHiggs_semiLep/DarkHiggs_SemiLep_MZP_195_neg/201001_141134/0000/']}
+Samples['DarkHiggs_SemiLep_MZP_200_pos'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_darkHiggs_semiLep/DarkHiggs_SemiLep_MZP_200_pos/201001_141146/0000/']}
+Samples['DarkHiggs_SemiLep_MZP_200_neg'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_darkHiggs_semiLep/DarkHiggs_SemiLep_MZP_200_neg/201001_141156/0000/']}
+Samples['DarkHiggs_SemiLep_MZP_295_pos'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_darkHiggs_semiLep/DarkHiggs_SemiLep_MZP_295_pos/201001_141207/0000/']}
+Samples['DarkHiggs_SemiLep_MZP_295_neg'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_darkHiggs_semiLep/DarkHiggs_SemiLep_MZP_295_neg/201001_141218/0000/']}
+Samples['DarkHiggs_SemiLep_MZP_300_pos'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_darkHiggs_semiLep/DarkHiggs_SemiLep_MZP_300_pos/201001_141228/0000/']}
+Samples['DarkHiggs_SemiLep_MZP_300_neg'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_darkHiggs_semiLep/DarkHiggs_SemiLep_MZP_300_neg/201001_141238/0000/']}
+Samples['DarkHiggs_SemiLep_MZP_500_pos'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_darkHiggs_semiLep/DarkHiggs_SemiLep_MZP_500_pos/201001_141249/0000/']}
+Samples['DarkHiggs_SemiLep_MZP_500_neg'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_darkHiggs_semiLep/DarkHiggs_SemiLep_MZP_500_neg/201001_141300/0000/']}
+Samples['DarkHiggs_SemiLep_MZP_1000_pos'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_darkHiggs_semiLep/DarkHiggs_SemiLep_MZP_1000_pos/201001_141310/0000/']}
+Samples['DarkHiggs_SemiLep_MZP_1000_neg'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_darkHiggs_semiLep/DarkHiggs_SemiLep_MZP_1000_neg/201001_141321/0000/']}
+Samples['DarkHiggs_SemiLep_MZP_1200_pos'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_darkHiggs_semiLep/DarkHiggs_SemiLep_MZP_1200_pos/201001_141331/0000/']}
+Samples['DarkHiggs_SemiLep_MZP_1200_neg'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_darkHiggs_semiLep/DarkHiggs_SemiLep_MZP_1200_neg/201001_141341/0000/']}
+Samples['DarkHiggs_SemiLep_MZP_1500_pos'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_darkHiggs_semiLep/DarkHiggs_SemiLep_MZP_1500_pos/201001_141351/0000/']}
+Samples['DarkHiggs_SemiLep_MZP_1500_neg'] = {'srmPrefix': 'gsiftp://eoscmsftp.cern.ch//eos/cms/' , "paths":['/store/group/phys_muon/friccita/MonoH/SemiLep/monoHiggsMC_darkHiggs_semiLep/DarkHiggs_SemiLep_MZP_1500_neg/201001_141402/0000/']}


### PR DESCRIPTION
LatinoAnalysis/NanoGardener/python/framework/samples/fall17_102X_nAODv7.py has been updated to include the 2017 signal samples (2HDMa and DarkHiggs) for the semileptonic analysis