### PR TITLE
Mk table

### DIFF
--- a/ShapeAnalysis/scripts/mkTable.py
+++ b/ShapeAnalysis/scripts/mkTable.py
@@ -259,6 +259,7 @@ parser.add_argument('--mergedOnly', help='Use only categories that have been mer
 parser.add_argument('-u', '--uncertainties', help='If --fancyTable is selected, adds uncertainties (all or post) to the table')
 parser.add_argument('--csv', help='Outputs table in .csv format', action='store_true')
 parser.add_argument('--decimals', help='Number of decimals to be shown', type=int, default=2)
+parser.add_argument('--unblind', help='Include data in table', action='store_true')
 args = parser.parse_args()
 
 #------- Main --------------------------------------------------------------------------------------------------------------------------------------------#
@@ -312,6 +313,9 @@ if __name__ == '__main__':
 
     try: show_unc = args.uncertainties
     except: show_unc = None
+
+    if not args.unblind:
+        df = remove_processes(df,['Data'])
 
     if not args.fancyTable: get_latex(df, args.expected, args.background, args.signal, args.csv, args.decimals)
     else: get_latex_reduced(df, args.mergedOnly, args.expected, show_unc, args.csv, args.decimals, sample_order)

--- a/ShapeAnalysis/scripts/mlfitNormsToText.py
+++ b/ShapeAnalysis/scripts/mlfitNormsToText.py
@@ -68,3 +68,42 @@ while True:
             row = ["%-40s"%m.group(1), "%-25s"%m.group(2), "%10.3f"%(norm_s.getVal()),"%10.3f"%(norm_b.getVal())]
 	    print("{:<40} {:25} {:>20} {:>20}").format(*row)
             #print "%-30s %-30s %7.3f %7.3f" % (m.group(1), m.group(2), norm_s.getVal(), norm_b.getVal())
+
+# Get totals and data as well?
+categories = [key.GetName() for key in file.Get('shapes_prefit').GetListOfKeys()]
+for cat in categories:
+    for total in ['total','total_signal','total_background']:
+        vals = []
+        for fit in ['prefit','fit_s','fit_b']:
+            hist = file.Get("shapes_"+fit+"/"+cat+"/"+total)
+            err = ROOT.Double()
+            norm = hist.IntegralAndError(1,hist.GetNbinsX(),err)
+            vals += [norm,err]
+
+        if prefit and norm_p and errors:
+            row = ["%-40s"%cat, "%-25s"%total, "%10.3f +/- %-10.3f"%(vals[0],vals[1]), "%10.3f +/- %-10.3f"%(vals[2],vals[3]),"%10.3f +/- %-10.3f"%(vals[4],vals[5])]
+            print("{:<40} {:25} {:10} {:10} {:10}").format(*row)
+        else:
+            if norm_p and prefit:
+                row = ["%-40s"%cat, "%-25s"%total, "%10.3f"%(vals[0]), "%10.3f"%(vals[2]),"%10.3f"%(vals[4])]
+                print("{:<40} {:25} {:>20} {:>20} {:>20}").format(*row)
+            else:
+                row = ["%-40s"%cat, "%-25s"%total, "%10.3f"%(vals[2]),"%10.3f"%(vals[4])]
+                print("{:<40} {:25} {:>20} {:>20}").format(*row)
+
+    tgr = file.Get('shapes_prefit/'+cat+'/data')
+    data = sum(list(tgr.GetY()))
+
+    if prefit and norm_p and errors:
+        row = ["%-40s"%cat, "%-25s"%('Data'), "%10.3f +/- %-10.3f"%(data,0), "%10.3f +/- %-10.3f"%(data,0),"%10.3f +/- %-10.3f"%(data,0)]
+        print("{:<40} {:25} {:10} {:10} {:10}").format(*row)
+    else:
+        if norm_p and prefit:
+            row = ["%-40s"%cat, "%-25s"%('Data'), "%10.3f"%(data), "%10.3f"%(data),"%10.3f"%(data)]
+            print("{:<40} {:25} {:>20} {:>20} {:>20}").format(*row)
+        else:
+            row = ["%-40s"%cat, "%-25s"%('Data'), "%10.3f"%(data),"%10.3f"%(data)]
+            print("{:<40} {:25} {:>20} {:>20}").format(*row)
+
+
+


### PR DESCRIPTION
Modification to mkTable.py (and mlfitNormsToText.py) to get the data from the input rootfile instead of needing to specify a datacard. Default behavior is to not include the data in the table; data can be added using the option --unblind.

Other updates:
-- total signal and total background added to the table (also taken from input rootfile, so uncertainties should account for correlations)
-- Uncertainties option -u can be set to all (show prefit and postfit uncertainties) or post (postfit only)
-- merged table uses category order from categories_to_merge
-- sample_order can be specified in merging map