### PR TITLE
Updating y axis label format in PlotFactory

### DIFF
--- a/ShapeAnalysis/scripts/mkPlot.py
+++ b/ShapeAnalysis/scripts/mkPlot.py
@@ -72,6 +72,7 @@ if __name__ == '__main__':
     parser.add_option('--postFit', dest='postFit', help='Plot sum of post-fit backgrounds, and the data/post-fit ratio.' , default='n') 
 
     parser.add_option('--removeMCStat', dest='removeMCStat', help='Do not plot the MC statistics contribution in the uncertainty band', action='store_true', default=False)
+    parser.add_option('--extraLegend'   , dest='extraLegend'   , help='User-specified additional legend'          , default=None)
 
     parser.add_option('--plotFancy', dest='plotFancy', help='Plot fancy data - bkg plot' , action='store_true', default=False) 
 
@@ -163,7 +164,8 @@ if __name__ == '__main__':
 
     factory._plotFancy = opt.plotFancy
 
-
+    factory._extraLegend = opt.extraLegend
+    
     #samples = {}
     samples = OrderedDict()
     if opt.samplesFile == None :


### PR DESCRIPTION
Updating y axis label formatting to match official CMS prescription (https://twiki.cern.ch/twiki/bin/viewauth/CMS/Internal/PubGuidelines#Figures_and_tables). Specifically, labels now use the following format:
-- Fixed bin width: "Events / <bin size> <units>", e.g. "Events / 50 MeV" or "Events / 0.1 units"
-- Variable bin width: "Events / bin"
-- Variable bin width, dividing by bin width: "< Events / <unit> >", e.g. "< Events / GeV >"

Units taken from the x axis caption, assuming (unit) or [unit] notation. Default label may be overwritten using the 'yaxis' field in variables.py.

Also added --extraLegend option to place a label in the upper right corner of the plot -- can be used to indicate channel or other information. Optional and does not affect normal running.