### PR TITLE
Scale sample

### DIFF
--- a/ShapeAnalysis/scripts/mkDatacards.py
+++ b/ShapeAnalysis/scripts/mkDatacards.py
@@ -146,8 +146,11 @@ class DatacardFactory:
 #                        if not sampleName in killBinSig : killBinSig[sampleName] = []
 #                        killBinSig[sampleName].append(iBin)
 #                        histo.SetBinContent(iBin,0.)
-                    
-                  yields[sampleName] = histo.Integral()
+                   if 'scaleSample' in structure[sampleName]:
+                     scaleFactor = structure[sampleName]['scaleSample']
+                     histo.Scale(scaleFactor)
+                   
+                   yields[sampleName] = histo.Integral()
   
                 #
                 # Remove statistical uncertainty from the histogram
@@ -280,6 +283,10 @@ class DatacardFactory:
                         histoUp.SetDirectory(self._outFile)
                         histoDown.SetDirectory(self._outFile)
 
+                        if 'scaleSample' in structure[sampleName]:
+                          scaleFactor = structure[sampleName]['scaleSample']
+                          histoUp.Scale(scaleFactor)
+                          histoDown.Scale(scaleFactor)
                         if '/' in nuisance['samples'][sampleName]:
                           up, down = nuisance['samples'][sampleName].split('/')
                           histoUp.Scale(float(up))
@@ -341,7 +348,7 @@ class DatacardFactory:
                           if self._skipMissingNuisance:
                             card.write(('-').ljust(columndef)) 
                             continue
-
+                        
                         histoIntegral = histo.Integral()
                         histoUpIntegral = histoUp.Integral()
                         histoDownIntegral = histoDown.Integral()
@@ -356,6 +363,7 @@ class DatacardFactory:
                           diffDo = 0.
 
                         if 'symmetrize' in nuisance and nuisance['symmetrize']:
+                          print nuisance,'is being symmetrized'
                           diff = (diffUp - diffDo) * 0.5
                           if diff >= 1.:
                               # can't symmetrize
@@ -552,6 +560,10 @@ class DatacardFactory:
           if self._skipMissingNuisance:
             return False
           # else let ROOT raise
+        if 'scaleSample' in structure[sampleName]:
+          scaleFactor = structure[sampleName]['scaleSample']
+          histoUp.Scale(scaleFactor)
+          histoDown.Scale(scaleFactor)
 
         if symmetrize:
           histoNom = self._getHisto(cutName, variableName, sampleName)

--- a/ShapeAnalysis/scripts/mkDatacards.py
+++ b/ShapeAnalysis/scripts/mkDatacards.py
@@ -146,8 +146,8 @@ class DatacardFactory:
 #                        if not sampleName in killBinSig : killBinSig[sampleName] = []
 #                        killBinSig[sampleName].append(iBin)
 #                        histo.SetBinContent(iBin,0.)
-                   if 'scaleSample' in structure[sampleName]:
-                     scaleFactor = structure[sampleName]['scaleSample']
+                   if 'scaleSampleForDatacard' in structure[sampleName]:
+                     scaleFactor = structure[sampleName]['scaleSampleForDatacard']
                      histo.Scale(scaleFactor)
                    
                    yields[sampleName] = histo.Integral()
@@ -283,8 +283,8 @@ class DatacardFactory:
                         histoUp.SetDirectory(self._outFile)
                         histoDown.SetDirectory(self._outFile)
 
-                        if 'scaleSample' in structure[sampleName]:
-                          scaleFactor = structure[sampleName]['scaleSample']
+                        if 'scaleSampleForDatacard' in structure[sampleName]:
+                          scaleFactor = structure[sampleName]['scaleSampleForDatacard']
                           histoUp.Scale(scaleFactor)
                           histoDown.Scale(scaleFactor)
                         if '/' in nuisance['samples'][sampleName]:
@@ -560,8 +560,8 @@ class DatacardFactory:
           if self._skipMissingNuisance:
             return False
           # else let ROOT raise
-        if 'scaleSample' in structure[sampleName]:
-          scaleFactor = structure[sampleName]['scaleSample']
+        if 'scaleSampleForDatacard' in structure[sampleName]:
+          scaleFactor = structure[sampleName]['scaleSampleForDatacard']
           histoUp.Scale(scaleFactor)
           histoDown.Scale(scaleFactor)
 

--- a/ShapeAnalysis/scripts/mkDatacards.py
+++ b/ShapeAnalysis/scripts/mkDatacards.py
@@ -146,11 +146,18 @@ class DatacardFactory:
 #                        if not sampleName in killBinSig : killBinSig[sampleName] = []
 #                        killBinSig[sampleName].append(iBin)
 #                        histo.SetBinContent(iBin,0.)
-                   if 'scaleSampleForDatacard' in structure[sampleName]:
-                     scaleFactor = structure[sampleName]['scaleSampleForDatacard']
-                     histo.Scale(scaleFactor)
-                   
-                   yields[sampleName] = histo.Integral()
+                  if 'scaleSampleForDatacard' in structure[sampleName]:
+                    scaleFactor = 1.
+                    if type(structure[sampleName]['scaleSampleForDatacard']) is dict:
+                      try:
+                        scaleFactor = structure[sampleName]['scaleSampleForDatacard'][cutName]
+                      except:
+                        pass
+                    if type(structure[sampleName]['scaleSampleForDatacard']) is int or type(structure[sampleName]['scaleSampleForDatacard']) is float:
+                      scaleFactor = structure[sampleName]['scaleSampleForDatacard']
+                    histo.Scale(scaleFactor)
+                  
+                  yields[sampleName] = histo.Integral()
   
                 #
                 # Remove statistical uncertainty from the histogram
@@ -284,7 +291,14 @@ class DatacardFactory:
                         histoDown.SetDirectory(self._outFile)
 
                         if 'scaleSampleForDatacard' in structure[sampleName]:
-                          scaleFactor = structure[sampleName]['scaleSampleForDatacard']
+                          scaleFactor = 1.
+                          if type(structure[sampleName]['scaleSampleForDatacard']) is dict:
+                            try:
+                              scaleFactor = structure[sampleName]['scaleSampleForDatacard'][cutName]
+                            except:
+                              pass
+                          if type(structure[sampleName]['scaleSampleForDatacard']) is int or type(structure[sampleName]['scaleSampleForDatacard']) is float:
+                            scaleFactor = structure[sampleName]['scaleSampleForDatacard']
                           histoUp.Scale(scaleFactor)
                           histoDown.Scale(scaleFactor)
                         if '/' in nuisance['samples'][sampleName]:
@@ -560,7 +574,14 @@ class DatacardFactory:
             return False
           # else let ROOT raise
         if 'scaleSampleForDatacard' in structure[sampleName]:
-          scaleFactor = structure[sampleName]['scaleSampleForDatacard']
+          scaleFactor = 1.
+          if type(structure[sampleName]['scaleSampleForDatacard']) is dict:
+            try:
+              scaleFactor = structure[sampleName]['scaleSampleForDatacard'][cutName]
+            except:
+              pass
+          if type(structure[sampleName]['scaleSampleForDatacard']) is int or type(structure[sampleName]['scaleSampleForDatacard']) is float:
+            scaleFactor = structure[sampleName]['scaleSampleForDatacard']
           histoUp.Scale(scaleFactor)
           histoDown.Scale(scaleFactor)
 

--- a/ShapeAnalysis/scripts/mkDatacards.py
+++ b/ShapeAnalysis/scripts/mkDatacards.py
@@ -363,7 +363,6 @@ class DatacardFactory:
                           diffDo = 0.
 
                         if 'symmetrize' in nuisance and nuisance['symmetrize']:
-                          print nuisance,'is being symmetrized'
                           diff = (diffUp - diffDo) * 0.5
                           if diff >= 1.:
                               # can't symmetrize


### PR DESCRIPTION
mkDatacards.py has been updated in order to have the possibility to scale processes by a scale factor. One can now simply scale a given sample - and all related shape nuisances - by adding the 'scaleSample' key in the corresponding sample dictionary defined in structure.py. The value is the scale factor itself.