### PR TITLE
Added possibility to blind non-contiguous sets of bins

### DIFF
--- a/ShapeAnalysis/python/PlotFactory.py
+++ b/ShapeAnalysis/python/PlotFactory.py
@@ -301,6 +301,11 @@ class PlotFactory:
                         if iBin >= b0 and iBin <= b1:
                           histos[sampleName].SetBinContent(iBin, 0)
                           histos[sampleName].SetBinError  (iBin, 0)
+                    # Allow to also pass arbitrary set of bin indexes to blind (e.g. for unrolled 2D histos)
+                    elif type(blind_range) in [list,tuple] and len(blind_range)>2:
+                      for iBin in blind_range:
+                        histos[sampleName].SetBinContent(iBin, 0)
+                        histos[sampleName].SetBinError  (iBin, 0)
 
                 thsData.Add(histos[sampleName])
 


### PR DESCRIPTION
Small tweak to the 'blind' feature in PlotFactory. You can now additionally pass it a set of bin indexes such as:

variables['test'] = { ...
                              'blind' = { category : (1, 2, 6, 7, 8) }
                             }

to blind the corresponding bins. This may be useful for example in case one wants to blind a given range in an X variable of a 2D unrolled plot of (X, Y)
