### PR TITLE
Protection for missing files and removal of all mc in legend

### DIFF
--- a/ShapeAnalysis/python/PlotFactory.py
+++ b/ShapeAnalysis/python/PlotFactory.py
@@ -53,6 +53,9 @@ class PlotFactory:
         self._fileFormats = ['png', 'root']
         
         self._preliminary = True
+        
+        self._removeAllMC = False
+        
 
     # _____________________________________________________________________________
     def makePlot(self, inputFile, outputDirPlots, variables, cuts, samples, plot, nuisances, legend, groupPlot):
@@ -1043,14 +1046,15 @@ class PlotFactory:
                       print " nevents [", sampleName, "] = ", nevents
                       tlegend.AddEntry(histos[sampleName], sampleName + " [" +  str(round(nevents,1)) + "]", "EPL")
               
-              
-            #                               if there is "histo_total" there is no need of explicit nuisances
-            if len(mynuisances.keys()) != 0 or histo_total!= None:
-                if self._showIntegralLegend == 0 :
-                    tlegend.AddEntry(tgrMC, "All MC", "F")
-                else :
-                    print " nexpected  = ", nexpected
-                    tlegend.AddEntry(tgrMC, "All MC [" + str(round(nexpected,1)) + "]", "F")
+            # add "All MC" in the legend
+            if not self._removeAllMC :
+              #                     if there is "histo_total" there is no need of explicit nuisances
+              if len(mynuisances.keys()) != 0 or histo_total!= None:
+                  if self._showIntegralLegend == 0 :
+                      tlegend.AddEntry(tgrMC, "All MC", "F")
+                  else :
+                      print " nexpected  = ", nexpected
+                      tlegend.AddEntry(tgrMC, "All MC [" + str(round(nexpected,1)) + "]", "F")
              
             tlegend.SetNColumns(2)
             tlegend.Draw()

--- a/ShapeAnalysis/scripts/mkPlot.py
+++ b/ShapeAnalysis/scripts/mkPlot.py
@@ -79,6 +79,7 @@ if __name__ == '__main__':
     parser.add_option('--plotFancy', dest='plotFancy', help='Plot fancy data - bkg plot' , action='store_true', default=False) 
 
     parser.add_option('--NoPreliminary', dest='NoPreliminary', help='Remove preliminary status in plots' , action='store_true', default=False) 
+    parser.add_option('--RemoveAllMC', dest='RemoveAllMC', help='Remove all MC in legend' , action='store_true', default=False) 
 
     # read default parsing options as well
     hwwtools.addOptions(parser)
@@ -111,6 +112,7 @@ if __name__ == '__main__':
     print "               removeMCStat  =", opt.removeMCStat
     print "                  plotFancy  =", opt.plotFancy
     print "              NoPreliminary  =", opt.NoPreliminary   
+    print "                RemoveAllMC  =", opt.RemoveAllMC   
     print ""
 
     opt.scaleToPlot = float(opt.scaleToPlot)
@@ -174,12 +176,20 @@ if __name__ == '__main__':
     factory._extraLegend = opt.extraLegend
     
     factory._preliminary = not opt.NoPreliminary
+    
+    factory._removeAllMC = opt.RemoveAllMC
+
 
     #samples = {}
     samples = OrderedDict()
     if opt.samplesFile == None :
       print " Please provide the samples structure (not strictly needed in mkPlot, since list of samples read from plot.py) "    
     elif os.path.exists(opt.samplesFile) :
+      # This line is needed for mkplot not to look for samples in eos.
+      # Imagine the samples have been removed in eos, but the file with histograms
+      # has been already generated, there is no need to check the existence of the samples on eos
+      # NB: in samples.py the function "nanoGetSampleFiles" must handle this, if needed
+      _samples_noload = True
       handle = open(opt.samplesFile,'r')
       exec(handle)
       handle.close()


### PR DESCRIPTION
While running mkplot.py the files on eos with the trees could have been already removed.
The "_samples_noload" option was already in some samples.py configuration, but it was not showing in mkplot.py (maybe some private code?)
Now it is part of mkplot.py, so that mkplot.py does not require the presence of trees to make the plots.

In samples.py you should have something like this, if you want to exploit this feature:


```
def nanoGetSampleFiles(inputDir, sample):
    try:
        if _samples_noload:
            return []
    except NameError:
        pass

    return getSampleFiles(inputDir, sample, True, 'nanoLatino_')

```



The other modification in this PR is the option to remove of "All MC" in the legend (for some papers we may want to remove ...)
To do so run mkplot.py with the option:

```
--RemoveAllMC
```


