### PR TITLE
Speed up mkDatacards.py

### DIFF
--- a/ShapeAnalysis/scripts/mkDatacards.py
+++ b/ShapeAnalysis/scripts/mkDatacards.py
@@ -45,6 +45,7 @@ class DatacardFactory:
               raise RuntimeError('Input file for sample ' + sampleName + ' missing')
         else:
           self._fileIn = ROOT.TFile(inputFile, "READ")
+          ROOT.gROOT.GetListOfFiles().Remove(self._fileIn) #Speed up?
 
         # categorize the sample names
         signal_ids = collections.OrderedDict() # id map of alternative_signals + cumulative_signals


### PR DESCRIPTION
Noticed that mkDatacards.py can get stuck at cleanup, e.g. when closing input file
Following https://root-forum.cern.ch/t/tfile-close-slow/24179 added line to remove input file from list of files
Cleanup of histograms should be unaffected, since all histograms should be owned by output files -- SetDirectory(self._outFile) is called for all histograms read from input file