### PR TITLE
Possibilty to have different line styles in normalized plots

### DIFF
--- a/ShapeAnalysis/python/PlotFactory.py
+++ b/ShapeAnalysis/python/PlotFactory.py
@@ -2357,23 +2357,24 @@ class PlotFactory:
 
                 hentry.DrawNormalized("hist,same")
                   
-              for hentry in thsSignal_grouped.GetHists():
-                num_bins = hentry.GetNbinsX()
-                if hentry.Integral() > 0.:
-                  y_normalized = hentry.GetBinContent(hentry.GetMaximumBin())/hentry.Integral()
-                  if y_normalized > maxY_normalized:
-                    maxY_normalized = y_normalized
-
-                for ibin in range( num_bins ) :
-                  hentry.SetBinError(ibin+1, 0.000001)
-
-                hentry.SetFillStyle(0)
-                hentry.SetLineWidth(3)
-                for sampleNameGroup, sampleConfiguration in groupPlot.iteritems():         
-                  if ('new_histo_group_' + sampleNameGroup  + '_' ) in hentry.GetName() :
-                    if 'line' in sampleConfiguration.keys(): 
-                      hentry.SetLineStyle(self._getLine(sampleConfiguration['line']))
-                hentry.DrawNormalized("hist,same")
+              if thsSignal_grouped.GetNhists() != 0:
+                for hentry in thsSignal_grouped.GetHists():
+                  num_bins = hentry.GetNbinsX()
+                  if hentry.Integral() > 0.:
+                    y_normalized = hentry.GetBinContent(hentry.GetMaximumBin())/hentry.Integral()
+                    if y_normalized > maxY_normalized:
+                      maxY_normalized = y_normalized
+                
+                  for ibin in range( num_bins ) :
+                    hentry.SetBinError(ibin+1, 0.000001)
+                
+                  hentry.SetFillStyle(0)
+                  hentry.SetLineWidth(3)
+                  for sampleNameGroup, sampleConfiguration in groupPlot.iteritems():         
+                    if ('new_histo_group_' + sampleNameGroup  + '_' ) in hentry.GetName() :
+                      if 'line' in sampleConfiguration.keys(): 
+                        hentry.SetLineStyle(self._getLine(sampleConfiguration['line']))
+                  hentry.DrawNormalized("hist,same")
 
               # ~~~~~~~~~~~~~~~~~~~~
               # include data only if required
@@ -2428,7 +2429,7 @@ class PlotFactory:
                   maxY_normalized = temp_maxY_normalized
                 
               for hentry in thsBackground_grouped.GetHists():  
-                if hentry not in thsSignal_grouped.GetHists() :   # since signal is part of the "background" for plotting reason
+                if (thsSignal_grouped.GetNhists()==0) or (hentry not in thsSignal_grouped.GetHists()) :   # since signal is part of the "background" for plotting reason
                   num_bins = hentry.GetNbinsX()
                   for ibin in range( num_bins ) :
                     hentry.SetBinError(ibin+1, 0.000001)
@@ -2437,16 +2438,17 @@ class PlotFactory:
                   hentry.Scale(normalization_factor_background)
                   thsBackground_grouped_normalized.Add(hentry)
 
-              for hentry in thsSignal_grouped.GetHists():               
-                num_bins = hentry.GetNbinsX()
-                for ibin in range( num_bins ) :
-                  hentry.SetBinError(ibin+1, 0.000001)
-                hentry.SetFillStyle(0)
-                hentry.SetLineWidth(3)
-                hentry.Scale(normalization_factor_signal)
-                thsSignal_grouped_normalized.Add(hentry)
+              if thsSignal_grouped.GetNhists() != 0:
+                for hentry in thsSignal_grouped.GetHists():               
+                  num_bins = hentry.GetNbinsX()
+                  for ibin in range( num_bins ) :
+                    hentry.SetBinError(ibin+1, 0.000001)
+                  hentry.SetFillStyle(0)
+                  hentry.SetLineWidth(3)
+                  hentry.Scale(normalization_factor_signal)
+                  thsSignal_grouped_normalized.Add(hentry)
 
-              thsSignal_grouped_normalized.Draw("hist same noclear")
+                thsSignal_grouped_normalized.Draw("hist same noclear")
               thsBackground_grouped_normalized.Draw("hist same noclear")
 
               frameNormTHstack.GetYaxis().SetRangeUser(0, 1.8*maxY_normalized)
@@ -2666,8 +2668,7 @@ class PlotFactory:
 
 
     def _getLine(self, line):
-      if type(color) == int:
-        return color
+      return line
 
 
 

--- a/ShapeAnalysis/python/PlotFactory.py
+++ b/ShapeAnalysis/python/PlotFactory.py
@@ -2349,6 +2349,12 @@ class PlotFactory:
 
                 hentry.SetFillStyle(0)
                 hentry.SetLineWidth(3)
+                
+                for sampleNameGroup, sampleConfiguration in groupPlot.iteritems():         
+                  if ('new_histo_group_' + sampleNameGroup  + '_' ) in hentry.GetName() :
+                    if 'line' in sampleConfiguration.keys(): 
+                      hentry.SetLineStyle(self._getLine(sampleConfiguration['line']))
+
                 hentry.DrawNormalized("hist,same")
                   
               for hentry in thsSignal_grouped.GetHists():
@@ -2363,6 +2369,10 @@ class PlotFactory:
 
                 hentry.SetFillStyle(0)
                 hentry.SetLineWidth(3)
+                for sampleNameGroup, sampleConfiguration in groupPlot.iteritems():         
+                  if ('new_histo_group_' + sampleNameGroup  + '_' ) in hentry.GetName() :
+                    if 'line' in sampleConfiguration.keys(): 
+                      hentry.SetLineStyle(self._getLine(sampleConfiguration['line']))
                 hentry.DrawNormalized("hist,same")
 
               # ~~~~~~~~~~~~~~~~~~~~
@@ -2371,6 +2381,8 @@ class PlotFactory:
               if self._plotNormalizedIncludeData : 
                 for sampleName, plotdef in plot.iteritems():
                   if plotdef['isData'] == 1 :
+                    if 'line' in plotdef.keys(): 
+                      histos[sampleName].SetLineStyle(self._getLine(plotdef['line']))
                     histos[sampleName].DrawNormalized("p, same")
 
               frameNorm.GetYaxis().SetRangeUser(0, 1.8*maxY_normalized)
@@ -2651,4 +2663,11 @@ class PlotFactory:
       elif type(color) == str:
         # hex string
         return ROOT.TColor.GetColor(color)
+
+
+    def _getLine(self, line):
+      if type(color) == int:
+        return color
+
+
 


### PR DESCRIPTION
Add the possibility to have different line styles in normalized plots.
Requested during the review on SMP-20-013.

Options should be in groupPlot


`

groupPlot['VVV']  = {  
                  'nameHR' : 'VVV',
                  'isSignal' : 0,
                  'color': 857, # kAzure -3  
                  'samples'  : ['VVV']
                  'line'   :    3    
              }

`


Standard line styles:
https://root.cern.ch/doc/master/classTAttLine.html#ATTLINE3


@valsdav to test