### PR TITLE
Add perRecoBin functionality in mkDatacards.py

### DIFF
--- a/ShapeAnalysis/scripts/mkDatacards.py
+++ b/ShapeAnalysis/scripts/mkDatacards.py
@@ -272,7 +272,10 @@ class DatacardFactory:
 
                 if nuisance['type'] in ['lnN', 'lnU']:
                   # why is adding CMS_ not the default for lnN/lnU? (Y.I. 2019.11.06)
+
                   entryName = nuisance['name']
+                  if 'perRecoBin' in nuisance.keys() and  nuisance['perRecoBin'] == True:
+                    entryName += "_"+cutName
 
                   card.write(entryName.ljust(80-20))
 
@@ -343,6 +346,9 @@ class DatacardFactory:
                     entryName = nuisance['name']
                   else:
                     entryName = 'CMS_' + nuisance['name']
+
+                  if 'perRecoBin' in nuisance.keys() and  nuisance['perRecoBin'] == True:
+                    entryName += "_"+cutName
 
                   card.write(entryName.ljust(80-20))
 
@@ -423,6 +429,13 @@ class DatacardFactory:
                         else:
                           suffixOut = '_CMS_' + nuisance['name']
 
+                        if 'perRecoBin' in nuisance.keys() and  nuisance['perRecoBin'] == True:
+                          if ('skipCMS' in nuisance.keys()) and nuisance['skipCMS'] == 1:
+                            suffixOut = "_"+nuisance['name']
+                          else:
+                            suffixOut = '_CMS_' + nuisance['name']
+                          suffixOut += "_"+cutName 
+ 
                         symmetrize = 'symmetrize' in nuisance and nuisance['symmetrize']
 
                         saved = self._saveNuisanceHistos(cutName, variableName, sampleName, '_' + nuisance['name'], suffixOut, symmetrize)


### PR DESCRIPTION
Adding the `perRecoBin: True` key in the nuisance dictionary will decorrelate the nuisance in each category.
The nuisance will be added in each datacard with a different name, appending the cut name to the nuisance name.
Here is an example
https://github.com/latinos/PlotsConfigurations/blob/42aeca3541d5e12139f572c4720dc5a304c98854/Configurations/ggH/Full2016_v7/HTXS_Stage1p2/nuisances.py#L103-L110