### PR TITLE
Adding option not to load samples in mkDatacards.py

### DIFF
--- a/ShapeAnalysis/scripts/mkDatacards.py
+++ b/ShapeAnalysis/scripts/mkDatacards.py
@@ -727,6 +727,8 @@ if __name__ == '__main__':
     factory._skipMissingNuisance = opt.skipMissingNuisance
     
     ## load the samples
+    ## Use flag to skip loading samples files, as currently done in mkPlot.py
+    _samples_noload = True
     samples = {}
     if os.path.exists(opt.samplesFile) :
       handle = open(opt.samplesFile,'r')


### PR DESCRIPTION
Adding the flag to mkDatacards.py not to load files when executing samples.py, as currently done in mkPlot.py