### PR TITLE
Adding option to scale RMS uncertainty

### DIFF
--- a/ShapeAnalysis/python/ShapeFactoryMulti.py
+++ b/ShapeAnalysis/python/ShapeFactoryMulti.py
@@ -1493,8 +1493,12 @@ class ShapeFactory:
                 elif nuisance['kind'].endswith('_rms'):
                   arrnom = np.tile(vnominal.flat, (variations.shape[0], 1))
                   arrv = np.sqrt(np.mean(np.square(variations - arrnom), axis=0))
-                  arrup = vnominal.flat[:] + arrv
-                  arrdown = vnominal.flat[:] - arrv
+                  if 'scale' in nuisance and sampleName+slabel in nuisance['scale']:
+                    arrup = vnominal.flat[:] + arrv*nuisance['scale'][sampleName+slabel][0]
+                    arrdown = vnominal.flat[:] - arrv*nuisance['scale'][sampleName+slabel][1]
+                  else:
+                    arrup = vnominal.flat[:] + arrv
+                    arrdown = vnominal.flat[:] - arrv
 
                 arrup = arrup.reshape(vnominal.shape)
                 arrdown = arrdown.reshape(vnominal.shape)


### PR DESCRIPTION
Adding the option to rescale a RMS uncertainty (ex. 2016 PDF) during the nuisance postprocessing
This allows ex. the normalization component of these uncertainties to be dropped
Tested in WW differential analysis -- see https://github.com/latinos/PlotsConfigurations/blob/master/Configurations/WW/FullRunII/Full2016_v7/inclusive/nuisances.py#L507
Syntax is to add a line with 'scale' : { sample : [scaleup, scaledown], ...} to nuisance 