### PR TITLE
Fix the random number run period generation

### DIFF
--- a/NanoGardener/python/modules/TrigMaker.py
+++ b/NanoGardener/python/modules/TrigMaker.py
@@ -94,6 +94,7 @@ class TrigMaker(Module):
         self.TM_GlEff = {}
         #self.TM_trkSFMu = {}
         self.TM_runInt  = {}
+        self.TM_runPeriods = []
         for RunP in self.Trigger[self.cmssw]:
            #self.TM_trkSFMu[RunP] = deepcopy(self.Trigger[self.cmssw][RunP]['trkSFMu'])
            self.TM_trig[RunP]    = {}
@@ -103,6 +104,7 @@ class TrigMaker(Module):
            self.TM_DZEffMC[RunP]   = {}
            self.TM_DRllSF[RunP]   = {}
            self.TM_GlEff[RunP] = {}
+           self.TM_runPeriods.append(RunP)
            if 'runList' in self.Trigger[self.cmssw][RunP].keys():
              self.TM_runInt[RunP]  = {'runList' : self.Trigger[self.cmssw][RunP]['runList']}
            else: 
@@ -172,6 +174,7 @@ class TrigMaker(Module):
 
 
         # Set some run/event specific var
+        self.TM_runPeriods.sort()
         self.total_lum = 0.
         self.EMTFbug = {}
         for RunP in self.Trigger[self.cmssw]:
@@ -199,9 +202,9 @@ class TrigMaker(Module):
          toss_a_coin = get_rndm(event_seed)
          for iPeriod in range(1,len(self.RunFrac)) :
            if toss_a_coin >= self.RunFrac[iPeriod-1] and toss_a_coin < self.RunFrac[iPeriod]:
-              return iPeriod
+              return self.TM_runPeriods[iPeriod-1]
            if toss_a_coin == 1.0:
-              return len(self.RunFrac)-1
+              return self.TM_runPeriods[len(self.RunFrac)-1]
         print "Run Period undefined"
         return -1 
 


### PR DESCRIPTION
Tentative fix of the random run period generation.
It was previously crashing if the run period started from a number different than 1, as in the `Full2016v9noHIPM` era.