### PR TITLE
Produce and use btagSFs for minimal set of JES uncertainties

### DIFF
--- a/NanoGardener/python/framework/Steps_cfg.py
+++ b/NanoGardener/python/framework/Steps_cfg.py
@@ -3561,7 +3561,7 @@ Steps = {
                   'do4MC'      : True  ,
                   'do4Data'    : False  ,
                   'import'     : 'LatinoAnalysis.NanoGardener.modules.btagSFProducerLatinos' ,
-                  'declare'    : 'btagSFProducer_DeepCSV_UL = lambda : btagSFProducerLatinos(era="RPLME_CMSSW_shape", algo="deepcsv", jesSystsForShape=["jes","jesAbsolute","jesAbsolute_RPLME_YEAR","jesBBEC1","jesBBEC1_RPLME_YEAR","jesEC2","jesEC2_RPLME_YEAR","jesHF","jesHF_RPLME_YEAR","jesRelativeBal","jesRelativeSample_RPLME_YEAR"])',
+                  'declare'    : 'btagSFProducer_DeepCSV_UL = lambda : btagSFProducerLatinos(era="RPLME_CMSSW_shape", algo="deepcsv", jesSystsForShape=["jes","jesAbsolute","jesAbsolute_RPLME_YEAR","jesBBEC1","jesBBEC1_RPLME_YEAR","jesEC2","jesEC2_RPLME_YEAR","jesFlavorQCD","jesHF","jesHF_RPLME_YEAR","jesRelativeBal","jesRelativeSample_RPLME_YEAR"])',
                   'module'     : 'btagSFProducer_DeepCSV_UL()',
                  },
   'btagPerJet_DeepJet_UL': {
@@ -3569,7 +3569,7 @@ Steps = {
                   'do4MC'      : True  ,
                   'do4Data'    : False  ,
                   'import'     : 'LatinoAnalysis.NanoGardener.modules.btagSFProducerLatinos' ,
-                  'declare'    : 'btagSFProducer_DeepJet_UL = lambda : btagSFProducerLatinos(era="RPLME_CMSSW_shape", algo="deepjet", jesSystsForShape=["jes","jesAbsolute","jesAbsolute_RPLME_YEAR","jesBBEC1","jesBBEC1_RPLME_YEAR","jesEC2","jesEC2_RPLME_YEAR","jesHF","jesHF_RPLME_YEAR","jesRelativeBal","jesRelativeSample_RPLME_YEAR"])',
+                  'declare'    : 'btagSFProducer_DeepJet_UL = lambda : btagSFProducerLatinos(era="RPLME_CMSSW_shape", algo="deepjet", jesSystsForShape=["jes","jesAbsolute","jesAbsolute_RPLME_YEAR","jesBBEC1","jesBBEC1_RPLME_YEAR","jesEC2","jesEC2_RPLME_YEAR","jesFlavorQCD","jesHF","jesHF_RPLME_YEAR","jesRelativeBal","jesRelativeSample_RPLME_YEAR"])',
                   'module'     : 'btagSFProducer_DeepJet_UL()',
                  },
 

--- a/NanoGardener/python/framework/Steps_cfg.py
+++ b/NanoGardener/python/framework/Steps_cfg.py
@@ -3561,7 +3561,7 @@ Steps = {
                   'do4MC'      : True  ,
                   'do4Data'    : False  ,
                   'import'     : 'LatinoAnalysis.NanoGardener.modules.btagSFProducerLatinos' ,
-                  'declare'    : 'btagSFProducer_DeepCSV_UL = lambda : btagSFProducerLatinos(era="RPLME_CMSSW_shape", algo="deepcsv")',
+                  'declare'    : 'btagSFProducer_DeepCSV_UL = lambda : btagSFProducerLatinos(era="RPLME_CMSSW_shape", algo="deepcsv", jesSystsForShape=["jes","jesAbsolute","jesAbsolute_RPLME_YEAR","jesBBEC1","jesBBEC1_RPLME_YEAR","jesEC2","jesEC2_RPLME_YEAR","jesHF","jesHF_RPLME_YEAR","jesRelativeBal","jesRelativeSample_RPLME_YEAR"])',
                   'module'     : 'btagSFProducer_DeepCSV_UL()',
                  },
   'btagPerJet_DeepJet_UL': {
@@ -3569,7 +3569,7 @@ Steps = {
                   'do4MC'      : True  ,
                   'do4Data'    : False  ,
                   'import'     : 'LatinoAnalysis.NanoGardener.modules.btagSFProducerLatinos' ,
-                  'declare'    : 'btagSFProducer_DeepJet_UL = lambda : btagSFProducerLatinos(era="RPLME_CMSSW_shape", algo="deepjet")',
+                  'declare'    : 'btagSFProducer_DeepJet_UL = lambda : btagSFProducerLatinos(era="RPLME_CMSSW_shape", algo="deepjet", jesSystsForShape=["jes","jesAbsolute","jesAbsolute_RPLME_YEAR","jesBBEC1","jesBBEC1_RPLME_YEAR","jesEC2","jesEC2_RPLME_YEAR","jesHF","jesHF_RPLME_YEAR","jesRelativeBal","jesRelativeSample_RPLME_YEAR"])',
                   'module'     : 'btagSFProducer_DeepJet_UL()',
                  },
 

--- a/ShapeAnalysis/python/ShapeFactoryMulti.py
+++ b/ShapeAnalysis/python/ShapeFactoryMulti.py
@@ -357,7 +357,6 @@ class ShapeFactory:
 
           # Set overall weights on the nuisance up/down drawers
           for nuisanceName, ndrawers in nuisanceDrawers.iteritems():
-            # tree-type nuisances can in addition have weights for up / down
             nuisance = nuisances[nuisanceName]
             sampleVarWeights = nuisance['samples'][sampleName]
 
@@ -368,7 +367,14 @@ class ShapeFactory:
               else:
                 nuisanceweight = sampleweight
 
-              ndrawer.setReweight(nuisanceweight)
+              # For tree or suffix nuisances, might need to provide an event weight (when filling) different from the value in 'samples' (which goes into the datacard)
+              # For now this is not sample dependent (could change later)
+              if 'reweight' in nuisance:
+                nuisanceShift = ShapeFactory._make_reweight(nuisance['reweight'][ivar])
+                nuisanceweightfinal = ROOT.multidraw.ReweightSource(nuisanceweight, nuisanceShift)
+                ndrawer.setReweight(nuisanceweightfinal)
+              else:
+                ndrawer.setReweight(nuisanceweight)
 
               # if the nuisance drawer is built from independent files, length of chain can be
               # different from the length of tree weights


### PR DESCRIPTION
The BTV POG recommends applying the btagSF for a given JES variation in place of the nominal btagSF when producing the varied kinematics [1]. Currently, we cannot do this for two reasons:
1) We do not save the btagSFs for the minimal set of JES uncertainties (JESAbsolute, JESAbsolute_<year>, JESBBEC1, etc.) but only the btagSF for the combined JES variation
2) We don't have the functionality in mkShapesMulti.py to apply an event weight for a suffix systematic variation.

This PR should fix both issues. However, it has not been tested.