### PR TITLE
Swap AsLnN order

### DIFF
--- a/ShapeAnalysis/scripts/mkDatacards.py
+++ b/ShapeAnalysis/scripts/mkDatacards.py
@@ -387,7 +387,7 @@ class DatacardFactory:
                         if abs(lnNUp - 1.) < 5.e-4 and abs(lnNDo - 1.) < 5.e-4:
                           card.write(('-').ljust(columndef))
                         else:
-                          card.write((('%-.4f' % lnNUp)+"/"+('%-.4f' % lnNDo)).ljust(columndef))
+                          card.write((('%-.4f' % lnNDo)+"/"+('%-.4f' % lnNUp)).ljust(columndef))
                       else:
                         card.write(('-').ljust(columndef)) 
 


### PR DESCRIPTION
Currently, the AsLnN order is opposite that expected by combine [1]. This fixes the order, for cases where Latinos analyses using AsLnN for a common nuisance are combined with those which are not.
[1] https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/part2/settinguptheanalysis/#a-simple-counting-experiment