### PR TITLE
new type of nuisance, squared sum of variations

### DIFF
--- a/ShapeAnalysis/python/ShapeFactoryMulti.py
+++ b/ShapeAnalysis/python/ShapeFactoryMulti.py
@@ -369,7 +369,14 @@ class ShapeFactory:
               else:
                 nuisanceweight = sampleweight
 
-              ndrawer.setReweight(nuisanceweight)
+              # For tree or suffix nuisances, might need to provide an event weight (when filling) different from the value in 'samples' (which goes into the datacard)
+              # For now this is not sample dependent (could change later)
+              if 'reweight' in nuisance:
+                nuisanceShift = ShapeFactory._make_reweight(nuisance['reweight'][ivar])
+                nuisanceweightfinal = ROOT.multidraw.ReweightSource(nuisanceweight, nuisanceShift)
+                ndrawer.setReweight(nuisanceweightfinal)
+              else:
+                ndrawer.setReweight(nuisanceweight)
 
               # if the nuisance drawer is built from independent files, length of chain can be
               # different from the length of tree weights
@@ -752,7 +759,7 @@ class ShapeFactory:
                   if 'kind' not in nuisance:
                     continue
 
-                  if nuisance['kind'].endswith('_envelope') or nuisance['kind'].endswith('_rms'):
+                  if nuisance['kind'].endswith('_envelope') or nuisance['kind'].endswith('_rms')  or nuisance['kind'].endswith('_squaredSum') :
                     for ivar in range(len(configurationNuis)):
                       histoNameVar = 'histo_' + outputFormat.format(sample=sampleName, subsample=slabel, nuisance=('_%sV%dVar' % (nuisance['name'], ivar)))
                       hTotalVar = outDir.Get(histoNameVar)
@@ -1489,6 +1496,15 @@ class ShapeFactory:
                 if nuisance['kind'].endswith('_envelope'):
                   arrup = np.max(variations, axis=0)
                   arrdown = np.min(variations, axis=0)
+
+                elif nuisance['kind'].endswith('_squaredSum'):
+                  deltas = variations - vnominal
+                  deltas_up = np.where(deltas > 0, deltas, 0)  
+                  deltas_down = np.where(deltas < 0, deltas, 0) 
+                  delta_arrup = np.sqrt(np.sum(deltas_up**2, axis=0))
+                  delta_arrdown = np.sqrt(np.sum(deltas_down**2, axis=0))
+                  arrup = vnominal.flat[:] + delta_arrup
+                  arrdown = vnominal.flat[:] - delta_arrdown
 
                 elif nuisance['kind'].endswith('_rms'):
                   arrnom = np.tile(vnominal.flat, (variations.shape[0], 1))


### PR DESCRIPTION
New type of nuisance, for example pdf uncertainty with hessian
See chapter 6 of https://arxiv.org/abs/1510.03865

Nuisance: squared sum of the differences between "variations" and the nominal.

It is similar to the "rms" type, but this one maintains the possible asymmetries up/down, that are removed from the "rms" method.

To use this:

nuisances['QCDscale_'+sample] = {
            'name'  : 'QCDscale_'+sample,
            'kind'  : 'weight_squaredSum',
            'type'  : 'shape',
            'samples'  :  { sample: variations }
        }

